### PR TITLE
Control manager generalization

### DIFF
--- a/config/default/control_manager.yaml
+++ b/config/default/control_manager.yaml
@@ -47,6 +47,11 @@ safety:
   # after not receiving odometry for more than this, the failsafe landing will trigger
   odometry_max_missing_time: 0.1 # [s]
 
+  # trigger eland when the odometry corrections are too unreliable
+  # should be false when using custom odometry source without available innovation values
+  odometry_innovation_eland:
+    enabled: true
+
   # emergency landing (still feedback)
   eland:
 

--- a/launch/control_manager.launch
+++ b/launch/control_manager.launch
@@ -16,6 +16,7 @@
   <arg name="standalone" default="true" />
   <arg name="debug" default="false" />
   <arg name="custom_config" default="" />
+  <arg name="body_frame" default="fcu" />
 
     <!-- custom configs for trackers -->
   <arg name="custom_config_csv_tracker" default="" />
@@ -79,6 +80,7 @@
 
       <param name="enable_profiler" type="bool" value="$(arg PROFILER)" />
       <param name="uav_name" type="string" value="$(arg UAV_NAME)" />
+      <param name="body_frame" type="string" value="$(arg body_frame)" />
       <param name="g" value="$(arg g)" />
       <param name="uav_mass" value="$(arg UAV_MASS)" />
       <param name="body_disturbance_x" value="$(arg BODY_DISTURBANCE_X)" />

--- a/src/control_manager.cpp
+++ b/src/control_manager.cpp
@@ -109,7 +109,7 @@
 #define ESCALATING_FAILSAFE_STR "escalating_failsafe"
 #define FAILSAFE_STR "failsafe"
 #define INPUT_UAV_STATE 0
-#define INPUT_ODOMETY 1
+#define INPUT_ODOMETRY 1
 
 //}
 
@@ -861,7 +861,7 @@ void ControlManager::onInit() {
 
   param_loader.loadParam("state_input", _state_input_);
 
-  if (!(_state_input_ == INPUT_UAV_STATE || _state_input_ == INPUT_ODOMETY)) {
+  if (!(_state_input_ == INPUT_UAV_STATE || _state_input_ == INPUT_ODOMETRY)) {
     ROS_ERROR("[ControlManager]: the state_input parameter has to be in {0, 1}");
     ros::shutdown();
   }
@@ -1554,7 +1554,7 @@ void ControlManager::onInit() {
   if (_state_input_ == INPUT_UAV_STATE) {
     sh_uav_state_ = mrs_lib::SubscribeHandler<mrs_msgs::UavState>(shopts, "uav_state_in", uav_state_timeout, &ControlManager::timeoutUavState, this,
                                                                   &ControlManager::callbackUavState, this);
-  } else if (_state_input_ == INPUT_ODOMETY) {
+  } else if (_state_input_ == INPUT_ODOMETRY) {
     sh_odometry_ = mrs_lib::SubscribeHandler<nav_msgs::Odometry>(shopts, "odometry_in", uav_state_timeout, &ControlManager::timeoutUavState, this,
                                                                  &ControlManager::callbackOdometry, this);
   }
@@ -1807,7 +1807,7 @@ void ControlManager::timerStatus(const ros::TimerEvent& event) {
   // |                 publish the current heading                |
   // --------------------------------------------------------------
 
-  if (sh_uav_state_.hasMsg()) {
+  if (_state_input_ == INPUT_UAV_STATE && sh_uav_state_.hasMsg()) {
 
     try {
 


### PR DESCRIPTION
This PR fixes several issues preventing its use with custom (non MRS) odometry source and custom velocity controller.

Changelog:

- Odometry innovation message for eland during wild estimation corrections is now optional

- Body frame of published `cmd_odom` messages is now parametrized in launch file (in non MRS systems, the body frame is usually called `base_link`)

- Publishing of the tracker's velocity state on topic `cmd_twist_out` to allow using external velocity controllers

- Added a missing check of odometry type input

- Fixed some typos