### PR TITLE
Publishing diagnostics when there is a change of active tracker or controller

### DIFF
--- a/src/control_manager/control_manager.cpp
+++ b/src/control_manager/control_manager.cpp
@@ -7563,6 +7563,7 @@ std::tuple<bool, std::string> ControlManager::failsafe(void) {
     }
   }
 
+  publishDiagnostics();
   return std::tuple(true, "failsafe activated");
 }
 
@@ -8259,6 +8260,7 @@ std::tuple<bool, std::string> ControlManager::switchTracker(const std::string& t
     }
   }
 
+  publishDiagnostics();
   return std::tuple(true, ss.str());
 }
 
@@ -8373,6 +8375,7 @@ std::tuple<bool, std::string> ControlManager::switchController(const std::string
 
   setConstraintsToControllers(sanitized_constraints);
 
+  publishDiagnostics();
   return std::tuple(true, ss.str());
 }
 


### PR DESCRIPTION
Publish diagnostics not just periodically (timerStatus) but also when there are changes to active trackers or controllers.

Potential improvement if relying on the tracker status information for some applications.  To avoid being constrained by the timer status rate. 