### PR TITLE
Errorgraph integration

### DIFF
--- a/include/mrs_uav_managers/estimation_manager/estimator.h
+++ b/include/mrs_uav_managers/estimation_manager/estimator.h
@@ -17,6 +17,7 @@
 
 #include <mrs_lib/publisher_handler.h>
 #include <mrs_lib/attitude_converter.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 #include <mrs_lib/param_loader.h>
 #include <mrs_lib/mutex.h>
 
@@ -39,6 +40,7 @@ class Estimator {
 
 protected:
   mutable mrs_lib::PublisherHandler<mrs_msgs::msg::EstimatorDiagnostics> ph_diagnostics_;
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher>                   error_publisher_;
 
   rclcpp::Node::SharedPtr  node_;
   rclcpp::Clock::SharedPtr clock_;

--- a/launch/constraint_manager.launch.py
+++ b/launch/constraint_manager.launch.py
@@ -160,6 +160,7 @@ def generate_launch_description():
             # publishers
             ("~/diagnostics_out", "~/diagnostics"),
             ("~/profiler", "profiler"),
+            ("~/errors", "errors"),
             # services in
             ("~/set_constraints_in", "~/set_constraints"),
             ("~/constraints_override_in", "~/constraints_override"),

--- a/launch/control_manager.launch.py
+++ b/launch/control_manager.launch.py
@@ -334,6 +334,7 @@ def generate_launch_description():
             ("~/get_min_z_out", "safety_area_manager/get_min_z"),
             ("~/get_max_z_out", "safety_area_manager/get_max_z"),
             ("~/is_safety_area_enabled_out", "safety_area_manager/is_safety_zone_enabled"),
+            ("~/errors", "errors"),
         ],
     )
 

--- a/launch/estimation_manager.launch.py
+++ b/launch/estimation_manager.launch.py
@@ -198,6 +198,7 @@ def generate_launch_description():
             ("~/diagnostics_out", "~/diagnostics"),
             ("~/max_flight_z_agl_out", "~/max_flight_z_agl"),
             ("~/height_agl_out", "~/height_agl"),
+            ("~/errors", "errors"),
             # services in
             ("~/change_estimator_in", "~/change_estimator"),
             ("~/set_world_origin_in", "~/set_world_origin"),

--- a/launch/gain_manager.launch.py
+++ b/launch/gain_manager.launch.py
@@ -161,6 +161,7 @@ def generate_launch_description():
             # publishers
             ("~/diagnostics_out", "~/diagnostics"),
             ("~/profiler", "profiler"),
+            ("~/errors", "errors"),
             # services in
             ("~/set_gains_in", "~/set_gains"),
             # services out

--- a/launch/safety_area_manager.launch.py
+++ b/launch/safety_area_manager.launch.py
@@ -230,6 +230,7 @@ def generate_launch_description():
             ("~/max_z_in", "estimation_manager/max_flight_z_agl"),
             # publishers
             ("~/diagnostics_out", "~/diagnostics"),
+            ("~/errors", "errors"),
             # services
             ("~/point_in_safety_area_3d_in", "~/point_in_safety_area_3d"),
             ("~/point_in_safety_area_2d_in", "~/point_in_safety_area_2d"),

--- a/launch/transform_manager.launch.py
+++ b/launch/transform_manager.launch.py
@@ -185,6 +185,7 @@ def generate_launch_description():
             ("~/altitude_amsl_in", "hw_api/altitude"),
             # publishers
             ("~/profiler", "profiler"),
+            ("~/errors", "errors"),
             ("~/map_delay_out", "~/map_delay"),
             # services in
             ("~/set_world_origin_in", "~/set_world_origin"),

--- a/launch/uav_manager.launch.py
+++ b/launch/uav_manager.launch.py
@@ -213,6 +213,7 @@ def generate_launch_description():
             # publishers
             ("~/diagnostics_out", "~/diagnostics"),
             ("~/profiler", "profiler"),
+            ("~/errors", "errors"),
             # services in
             ("~/takeoff_in", "~/takeoff"),
             ("~/land_in", "~/land"),

--- a/src/constraint_manager.cpp
+++ b/src/constraint_manager.cpp
@@ -19,6 +19,7 @@
 #include <mrs_lib/service_client_handler.h>
 #include <mrs_lib/service_server_handler.h>
 #include <mrs_lib/subscriber_handler.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 //}
 
@@ -133,6 +134,10 @@ private:
   // | ------------------------- helpers ------------------------ |
 
   bool stringInVector(const std::string &value, const std::vector<std::string> &vector);
+
+  // | -------------------- error publisher --------------------- |
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
 };
 
 //}
@@ -153,6 +158,8 @@ void ConstraintManager::initialize() {
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "ConstraintManager", "main");
+
   cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -171,35 +178,35 @@ void ConstraintManager::initialize() {
   if (custom_config_path != "") {
     if (!param_loader.addYamlFile(custom_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load custom_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load custom_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (platform_config_path != "") {
     if (!param_loader.addYamlFile(platform_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load platform_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load platform_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (!param_loader.addYamlFileFromParam("private_config")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load private_config");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load private_config.");
+    error_publisher_->flushAndShutdown();
   }
 
   if (!param_loader.addYamlFileFromParam("public_config")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load public_config");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load public_config.");
+    error_publisher_->flushAndShutdown();
   }
 
   if (!param_loader.addYamlFileFromParam("public_constraints")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load public_constraints");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load public_constraints.");
+    error_publisher_->flushAndShutdown();
   }
 
   const std::string yaml_prefix = "mrs_uav_managers/constraint_manager/";
@@ -268,8 +275,8 @@ void ConstraintManager::initialize() {
     for (it2 = temp_vector.begin(); it2 != temp_vector.end(); ++it2) {
       if (!stringInVector(*it2, _constraint_names_)) {
         RCLCPP_ERROR(node_->get_logger(), "the element '%s' of %s/allowed_constraints is not a valid constraint!", it2->c_str(), it->c_str());
-        rclcpp::shutdown();
-        exit(1);
+        error_publisher_->addOneshotError("Invalid constraint '" + *it2 + "' in " + *it + "/allowed_constraints.");
+        error_publisher_->flushAndShutdown();
       }
     }
 
@@ -284,8 +291,8 @@ void ConstraintManager::initialize() {
 
     if (!stringInVector(temp_str, _map_type_allowed_constraints_.at(*it))) {
       RCLCPP_ERROR(node_->get_logger(), "the element '%s' of %s/allowed_constraints is not a valid constraint!", temp_str.c_str(), it->c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Invalid default constraint '" + temp_str + "' for " + *it + ".");
+      error_publisher_->flushAndShutdown();
     }
 
     _map_type_default_constraints_.insert(std::pair<std::string, std::string>(*it, temp_str));
@@ -357,8 +364,8 @@ void ConstraintManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "Could not load all parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   is_initialized_ = true;
@@ -381,6 +388,7 @@ bool ConstraintManager::setConstraints(std::string constraints_name) {
 
   if (it == _constraints_.end()) {
     RCLCPP_ERROR(node_->get_logger(), "could not setConstraints(), the constraint name '%s' is not on the list", constraints_name.c_str());
+    error_publisher_->addOneshotError("Constraint name '" + constraints_name + "' is not on the list.");
     return false;
   }
 
@@ -452,6 +460,7 @@ bool ConstraintManager::callbackSetConstraints(const std::shared_ptr<mrs_msgs::s
     ss << "missing odometry diagnostics";
 
     RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+    error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
 
     response->message = ss.str();
     response->success = false;
@@ -490,6 +499,7 @@ bool ConstraintManager::callbackSetConstraints(const std::shared_ptr<mrs_msgs::s
     ss << "the ControlManager could not set the constraints";
 
     RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+    error_publisher_->addOneshotError("The ControlManager could not set the constraints.");
 
     response->message = ss.str();
     response->success = false;
@@ -634,6 +644,7 @@ void ConstraintManager::timerDiagnostics() {
 
   if (!sh_estimation_diag_.hasMsg()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 10000, "can not do constraint management, missing estimation diagnostics!");
+    error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
     return;
   }
 

--- a/src/control_manager/control_manager.cpp
+++ b/src/control_manager/control_manager.cpp
@@ -52,6 +52,7 @@
 #include <mrs_lib/publisher_handler.h>
 #include <mrs_lib/service_client_handler.h>
 #include <mrs_lib/service_server_handler.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 #include <mrs_msgs/msg/hw_api_capabilities.hpp>
 #include <mrs_msgs/msg/hw_api_status.hpp>
@@ -249,6 +250,8 @@ private:
   std::atomic<bool> is_initialized_ = false;
   std::string       _uav_name_;
   std::string       _body_frame_;
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
 
   std::string _uav_dynamics_config_;
   std::string _custom_config_;
@@ -926,6 +929,8 @@ ControlManager::ControlManager(rclcpp::NodeOptions options) : mrs_lib::Node("con
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "ControlManager", "main");
+
   cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -1047,8 +1052,8 @@ void ControlManager::initialize(void) {
 
   if (_uav_mass_ <= 0.0) {
     RCLCPP_ERROR(node_->get_logger(), "nominal uav mass should be > 0.0.");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Invalid uav mass, must be > 0.0");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("body_disturbance_x", _initial_body_disturbance_x_);
@@ -1067,8 +1072,8 @@ void ControlManager::initialize(void) {
 
   if (!(_state_input_ == INPUT_UAV_STATE || _state_input_ == INPUT_ODOMETRY)) {
     RCLCPP_ERROR(node_->get_logger(), "the state_input parameter has to be in {0, 1}");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Invalid state_input parameter, must be in {0,1}");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("safety/min_throttle_null_tracker", _min_throttle_null_tracker_);
@@ -1101,8 +1106,8 @@ void ControlManager::initialize(void) {
 
   if (_tilt_limit_eland_enabled_ && fabs(_tilt_limit_eland_) < 1e-3) {
     RCLCPP_ERROR(node_->get_logger(), "safety/tilt_limit/eland/enabled = 'TRUE' but the limit is too low");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("safety/tilt_limit/eland/enabled = 'TRUE' but the limit is too low");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("safety/tilt_limit/disarm/enabled", _tilt_limit_disarm_enabled_);
@@ -1112,8 +1117,8 @@ void ControlManager::initialize(void) {
 
   if (_tilt_limit_disarm_enabled_ && fabs(_tilt_limit_disarm_) < 1e-3) {
     RCLCPP_ERROR(node_->get_logger(), "safety/tilt_limit/disarm/enabled = 'TRUE' but the limit is too low");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("safety/tilt_limit/disarm/enabled = 'TRUE' but the limit is too low");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("safety/yaw_error_eland/enabled", _yaw_error_eland_enabled_);
@@ -1123,8 +1128,8 @@ void ControlManager::initialize(void) {
 
   if (_yaw_error_eland_enabled_ && fabs(_yaw_error_eland_) < 1e-3) {
     RCLCPP_ERROR(node_->get_logger(), "safety/yaw_error_eland/enabled = 'TRUE' but the limit is too low");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("safety/yaw_error_eland/enabled = 'TRUE' but the limit is too low");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("status_timer_rate", _status_timer_rate_);
@@ -1143,8 +1148,8 @@ void ControlManager::initialize(void) {
 
   if (_tilt_error_disarm_enabled_ && fabs(_tilt_error_disarm_threshold_) < 1e-3) {
     RCLCPP_ERROR(node_->get_logger(), "safety/tilt_error_disarm/enabled = 'TRUE' but the limit is too low");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("safety/tilt_error_disarm/enabled = 'TRUE' but the limit is too low");
+    error_publisher_->flushAndShutdown();
   }
 
   // default constraints
@@ -1238,8 +1243,8 @@ void ControlManager::initialize(void) {
   if (_tracker_error_action_ != ELAND_STR && _tracker_error_action_ != EHOVER_STR) {
     RCLCPP_ERROR(node_->get_logger(), "the tracker_error_action parameter (%s) is not correct, requires {%s, %s}", _tracker_error_action_.c_str(), ELAND_STR,
                  EHOVER_STR);
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Invalid tracker_error_action parameter, must be in {eland, ehover}");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("rc_joystick/enabled", _rc_goto_enabled_);
@@ -1339,14 +1344,14 @@ void ControlManager::initialize(void) {
     catch (pluginlib::CreateClassException &ex1) {
       RCLCPP_ERROR(node_->get_logger(), "CreateClassException for the tracker '%s'", new_tracker.address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex1.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("CreateClassException for the tracker " + new_tracker.address + ": " + std::string(ex1.what()));
+      error_publisher_->flushAndShutdown();
     }
     catch (pluginlib::PluginlibException &ex) {
       RCLCPP_ERROR(node_->get_logger(), "PluginlibException for the tracker '%s'", new_tracker.address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the tracker " + new_tracker.address + ": " + std::string(ex.what()));
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1384,8 +1389,8 @@ void ControlManager::initialize(void) {
 
     if (!success) {
       RCLCPP_ERROR(node_->get_logger(), "failed to initialize the tracker '%s'", it->second.address.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to initialize the tracker " + it->second.address);
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1405,8 +1410,8 @@ void ControlManager::initialize(void) {
       _ehover_tracker_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the safety/hover_tracker (%s) is not within the loaded trackers", _ehover_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The safety/hover_tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1419,8 +1424,8 @@ void ControlManager::initialize(void) {
       _landoff_tracker_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the landoff tracker (%s) is not within the loaded trackers", _landoff_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The landoff tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1433,8 +1438,8 @@ void ControlManager::initialize(void) {
       _null_tracker_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the null tracker (%s) is not within the loaded trackers", _null_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The null tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1450,8 +1455,8 @@ void ControlManager::initialize(void) {
       _joystick_tracker_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the joystick tracker (%s) is not within the loaded trackers", _joystick_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The joystick tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1461,8 +1466,8 @@ void ControlManager::initialize(void) {
 
     if (!idx) {
       RCLCPP_ERROR(node_->get_logger(), "the bumper tracker (%s) is not within the loaded trackers", _bumper_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The bumper tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1473,8 +1478,8 @@ void ControlManager::initialize(void) {
       _joystick_fallback_tracker_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the joystick fallback tracker (%s) is not within the loaded trackers", _joystick_fallback_tracker_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The joystick fallback tracker is not within the loaded trackers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1591,15 +1596,16 @@ void ControlManager::initialize(void) {
           RCLCPP_ERROR(node_->get_logger(), "- position");
         }
 
-        rclcpp::shutdown();
-        exit(1);
+        error_publisher_->addOneshotError("The controller " + controller_name + " does not meet the control output requirements of the HW API");
+        error_publisher_->flushAndShutdown();
       }
 
       if ((_hw_api_inputs_.actuators || _hw_api_inputs_.control_group) && !common_handlers_->detailed_model_params) {
         RCLCPP_ERROR(node_->get_logger(),
                      "the HW API supports 'actuators' or 'control_group' input, but the 'detailed uav model params' were not loaded sucessfully");
-        rclcpp::shutdown();
-        exit(1);
+        error_publisher_->addOneshotError(
+            "The HW API supports 'actuators' or 'control_group' input, but the 'detailed uav model params' were not loaded sucessfully");
+        error_publisher_->flushAndShutdown();
       }
     }
 
@@ -1653,14 +1659,14 @@ void ControlManager::initialize(void) {
     catch (pluginlib::CreateClassException &ex1) {
       RCLCPP_ERROR(node_->get_logger(), "CreateClassException for the controller '%s'", new_controller.address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex1.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("CreateClassException for the controller " + new_controller.address + ": " + std::string(ex1.what()));
+      error_publisher_->flushAndShutdown();
     }
     catch (pluginlib::PluginlibException &ex) {
       RCLCPP_ERROR(node_->get_logger(), "PluginlibException for the controller '%s'", new_controller.address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the controller " + new_controller.address + ": " + std::string(ex.what()));
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1698,8 +1704,8 @@ void ControlManager::initialize(void) {
 
     if (!success) {
       RCLCPP_ERROR(node_->get_logger(), "failed to initialize the controller '%s'", it->second.address.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to initialize the controller " + it->second.address);
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1712,8 +1718,8 @@ void ControlManager::initialize(void) {
       _failsafe_controller_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the failsafe controller (%s) is not within the loaded controllers", _failsafe_controller_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The failsafe controller is not within the loaded controllers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1724,8 +1730,8 @@ void ControlManager::initialize(void) {
       _eland_controller_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the eland controller (%s) is not within the loaded controllers", _eland_controller_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The eland controller is not within the loaded controllers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1736,8 +1742,8 @@ void ControlManager::initialize(void) {
       _joystick_controller_idx_ = idx.value();
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the joystick controller (%s) is not within the loaded controllers", _joystick_controller_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The joystick controller is not within the loaded controllers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1747,8 +1753,8 @@ void ControlManager::initialize(void) {
 
     if (!idx) {
       RCLCPP_ERROR(node_->get_logger(), "the bumper controller (%s) is not within the loaded controllers", _bumper_controller_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The bumper controller is not within the loaded controllers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -1760,8 +1766,8 @@ void ControlManager::initialize(void) {
     } else {
       RCLCPP_ERROR(node_->get_logger(), "the joystick fallback controller (%s) is not within the loaded controllers",
                    _joystick_fallback_controller_name_.c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("The joystick fallback controller is not within the loaded controllers");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -2135,8 +2141,8 @@ void ControlManager::initialize(void) {
 
   if (!param_loader_->loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "could not load all parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all parameters");
+    error_publisher_->flushAndShutdown();
   }
 
   is_initialized_ = true;
@@ -2204,6 +2210,7 @@ void ControlManager::timerHwApiCapabilities() {
 
   if (!sh_hw_api_capabilities_.hasMsg()) {
     RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for HW API capabilities");
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return;
   }
 
@@ -4402,6 +4409,7 @@ bool ControlManager::callbackTrackerResetStatic([[maybe_unused]] const std::shar
     } else {
       message << "the tracker '" << tracker_name << "' reset failed!";
       RCLCPP_ERROR_STREAM(node_->get_logger(), "" << message.str());
+      error_publisher_->addOneshotError("Tracker reset failed");
     }
   }
 
@@ -4603,6 +4611,7 @@ bool ControlManager::callbackToggleOutput(const std::shared_ptr<std_srvs::srv::S
   if (!sh_hw_api_status_.hasMsg() || (clock_->now() - sh_hw_api_status_.lastMsgTime()).seconds() > 1.0) {
     ss << "cannot toggle output ON, missing HW API status!";
     prereq_check = false;
+    error_publisher_->addOneshotError("cannot toggle output ON, missing HW API status!");
   }
 
   if (!prereq_check) {
@@ -4653,6 +4662,7 @@ bool ControlManager::callbackArm(const std::shared_ptr<std_srvs::srv::SetBool::R
     response->success = false;
 
     RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+    error_publisher_->addOneshotError("Cannot arm/disarm during failsafe or eland");
 
     return true;
   }
@@ -4662,6 +4672,7 @@ bool ControlManager::callbackArm(const std::shared_ptr<std_srvs::srv::SetBool::R
     ss << "this service is not allowed to arm the UAV";
     response->success = false;
     RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+    error_publisher_->addOneshotError("Arming via service is disabled");
 
   } else {
 
@@ -4678,6 +4689,7 @@ bool ControlManager::callbackArm(const std::shared_ptr<std_srvs::srv::SetBool::R
       ss << "could not disarm: " << message;
       response->success = false;
       RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+      error_publisher_->addOneshotError("Disarming failed: " + message);
     }
   }
 
@@ -8253,6 +8265,7 @@ std::tuple<bool, std::string> ControlManager::switchController(const std::string
 
     ss << "can not switch controller, missing odometry innovation!";
     RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+    error_publisher_->addOneshotError("ControlManager: switchController: missing odometry innovation");
     return std::tuple(false, ss.str());
   }
 
@@ -8262,6 +8275,7 @@ std::tuple<bool, std::string> ControlManager::switchController(const std::string
   if (!new_controller_idx) {
     ss << "the controller '" << controller_name << "' does not exist!";
     RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+    error_publisher_->addOneshotError("The controller '" + controller_name + "' does not exist");
     return std::tuple(false, ss.str());
   }
 
@@ -8283,6 +8297,7 @@ std::tuple<bool, std::string> ControlManager::switchController(const std::string
 
         ss << "the controller '" << controller_name << "' was not activated";
         RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+        error_publisher_->addOneshotError("The controller '" + controller_name + "' was not activated");
         return std::tuple(false, ss.str());
 
       } else {

--- a/src/estimation_manager/estimation_manager.cpp
+++ b/src/estimation_manager/estimation_manager.cpp
@@ -29,6 +29,8 @@
 #include <mrs_lib/subscriber_handler.h>
 #include <mrs_lib/gps_conversions.h>
 #include <mrs_lib/scope_timer.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
+
 
 #include <mrs_uav_managers/state_estimator.h>
 #include <mrs_uav_managers/agl_estimator.h>
@@ -348,6 +350,17 @@ private:
   std::string _platform_config_;
   std::string _world_config_;
 
+  // | -------------------- errorgraph -------------------- |
+  enum class error_type_t : uint16_t
+  {
+    invalid_state,
+    nans_detected,
+    no_healthy_estimator_available,
+    in_failsafe_state,
+  };
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
+
   std::shared_ptr<CommonHandlers_t> ch_;
 
   std::shared_ptr<StateMachine> sm_;
@@ -457,6 +470,9 @@ EstimationManager::EstimationManager(rclcpp::NodeOptions options) : mrs_lib::Nod
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "EstimationManager", "main");
+
+
   cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -509,7 +525,7 @@ void EstimationManager::timerPreinit() {
 
     RCLCPP_INFO(node_->get_logger(), "%s hw_api_capabilities message at topic: %s", Support::waiting_for_string.c_str(),
                 sh_hw_api_capabilities_.topicName().c_str());
-
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     got_data = false;
   }
 
@@ -518,7 +534,7 @@ void EstimationManager::timerPreinit() {
 
     RCLCPP_INFO(node_->get_logger(), "%s control_manager_diagnostics message at topic: %s", Support::waiting_for_string.c_str(),
                 sh_control_manager_diag_.topicName().c_str());
-
+    error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
     got_data = false;
   }
 
@@ -595,8 +611,8 @@ void EstimationManager::initialize() {
 
   } else {
     RCLCPP_ERROR(node_->get_logger(), "world_origin_units must be (\"UTM\"|\"LATLON\"). Got '%s'", world_origin_units.c_str());
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("world_origin_units must be (\"UTM\"|\"LATLON\").");
+    error_publisher_->flushAndShutdown();
   }
 
   ch_->world_origin.x = world_origin_x;
@@ -604,8 +620,8 @@ void EstimationManager::initialize() {
 
   if (!is_origin_param_ok) {
     RCLCPP_ERROR(node_->get_logger(), "Could not load all mandatory parameters from world file. Please check your world file.");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all mandatory parameters from world file.");
+    error_publisher_->flushAndShutdown();
   }
   /*//}*/
 
@@ -707,14 +723,14 @@ void EstimationManager::initialize() {
     catch (pluginlib::CreateClassException &ex1) {
       RCLCPP_ERROR(node_->get_logger(), "CreateClassException for the estimator '%s'", address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex1.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the estimator " + estimator_name + ": " + ex1.what());
+      error_publisher_->flushAndShutdown();
     }
     catch (pluginlib::PluginlibException &ex) {
       RCLCPP_ERROR(node_->get_logger(), "PluginlibException for the estimator '%s'", address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the estimator " + estimator_name + ": " + ex.what());
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -741,14 +757,14 @@ void EstimationManager::initialize() {
     catch (pluginlib::CreateClassException &ex1) {
       RCLCPP_ERROR(node_->get_logger(), "CreateClassException for the estimator '%s'", address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex1.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the AGL estimator " + est_alt_agl_name_ + ": " + ex1.what());
+      error_publisher_->flushAndShutdown();
     }
     catch (pluginlib::PluginlibException &ex) {
       RCLCPP_ERROR(node_->get_logger(), "PluginlibException for the estimator '%s'", address.c_str());
       RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load the AGL estimator " + est_alt_agl_name_ + ": " + ex.what());
+      error_publisher_->flushAndShutdown();
     }
   }
   /*//}*/
@@ -769,8 +785,8 @@ void EstimationManager::initialize() {
 
   if (!initial_estimator_found) {
     RCLCPP_ERROR(node_->get_logger(), "initial estimator %s could not be found among loaded estimators. shutting down", initial_estimator_name_.c_str());
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Initial estimator " + initial_estimator_name_ + " could not be found among loaded estimators.");
+    error_publisher_->flushAndShutdown();
   }
   /*//}*/
 
@@ -792,14 +808,14 @@ void EstimationManager::initialize() {
     }
     catch (std::runtime_error &ex) {
       RCLCPP_ERROR(node_->get_logger(), "exception caught during estimator initialization: '%s'", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Exception caught during estimator " + estimator->getName() + " initialization: " + ex.what());
+      error_publisher_->flushAndShutdown();
     }
 
     if (!estimator->isCompatibleWithHwApi(hw_api_capabilities)) {
       RCLCPP_ERROR(node_->get_logger(), "estimator %s is not compatible with the hw api. Shutting down.", estimator->getName().c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Estimator " + estimator->getName() + " is not compatible with the hw api.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -820,14 +836,14 @@ void EstimationManager::initialize() {
     }
     catch (std::runtime_error &ex) {
       RCLCPP_ERROR(node_->get_logger(), "exception caught during estimator initialization: '%s'", ex.what());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Exception caught during AGL estimator " + est_alt_agl_->getName() + " initialization: " + ex.what());
+      error_publisher_->flushAndShutdown();
     }
 
     if (!est_alt_agl_->isCompatibleWithHwApi(hw_api_capabilities)) {
       RCLCPP_ERROR(node_->get_logger(), "estimator %s is not compatible with the hw api. Shutting down.", est_alt_agl_->getName().c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("AGL Estimator " + est_alt_agl_->getName() + " is not compatible with the hw api.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
@@ -912,8 +928,8 @@ void EstimationManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "Could not load all non-optional parameters. Shutting down.");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all non-optional parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   sm_->changeState(StateMachine::INITIALIZED_STATE);
@@ -941,11 +957,13 @@ void EstimationManager::timerPublish() {
 
   if (sm_->isInState(StateMachine::ESTIMATOR_SWITCHING_STATE)) {
     RCLCPP_WARN(node_->get_logger(), "Not publishing during estimator switching.");
+    error_publisher_->addGeneralError(error_type_t::invalid_state, "Not publishing during estimator switching.");
     return;
   }
 
   if (!sm_->isInPublishableState()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "not publishing uav state in %s", sm_->getCurrentStateString().c_str());
+    error_publisher_->addGeneralError(error_type_t::invalid_state, "Not publishing uav state in " + sm_->getCurrentStateString() + ".");
     return;
   }
 
@@ -955,11 +973,13 @@ void EstimationManager::timerPublish() {
     uav_state = ret.value();
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "Active estimator did not provide uav_state.");
+    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getName()});
     return;
   }
 
   if (!Support::noNans(uav_state.pose.orientation)) {
     RCLCPP_ERROR(node_->get_logger(), "NaN in uav state orientation");
+    error_publisher_->addGeneralError(error_type_t::nans_detected, "NaN in uav state orientation.");
     return;
   }
 
@@ -1030,11 +1050,13 @@ void EstimationManager::timerPublishDiagnostics() {
     uav_state = ret.value();
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "Active estimator did not provide uav_state.");
+    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getName()});
     return;
   }
 
   if (!Support::noNans(uav_state.pose.orientation)) {
     RCLCPP_ERROR(node_->get_logger(), "NaN in uav state orientation");
+    error_publisher_->addGeneralError(error_type_t::nans_detected, "NaN in uav state orientation.");
     return;
   }
 
@@ -1129,8 +1151,8 @@ void EstimationManager::timerCheckHealth() {
       }
       catch (std::runtime_error &ex) {
         RCLCPP_ERROR(node_->get_logger(), "exception caught during estimator starting: '%s'", ex.what());
-        rclcpp::shutdown();
-        exit(1);
+        error_publisher_->addOneshotError("Exception caught during estimator " + estimator->getName() + " starting: " + ex.what());
+        error_publisher_->flushAndShutdown();
       }
     }
 
@@ -1172,6 +1194,7 @@ void EstimationManager::timerCheckHealth() {
       } else {
         RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "%s agl estimator: %s to be running", Support::waiting_for_string.c_str(),
                              est_alt_agl_->getName().c_str());
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_agl_->getName()});
       }
     }
   }
@@ -1186,6 +1209,7 @@ void EstimationManager::timerCheckHealth() {
       sm_->changeToPreSwitchState();
     } else { // cannot switch to healthy estimator - failsafe necessary
       RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "Cannot switch to any healthy estimator. Triggering failsafe.");
+      error_publisher_->addGeneralError(error_type_t::no_healthy_estimator_available, "Cannot switch to any healthy estimator. Triggering failsafe.");
       sm_->changeState(StateMachine::FAILSAFE_STATE);
     }
   }
@@ -1196,6 +1220,7 @@ void EstimationManager::timerCheckHealth() {
       failsafe_call_succeeded_ = true;
     }
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "we are in failsafe state");
+    error_publisher_->addGeneralError(error_type_t::in_failsafe_state, "Estimation manager in failsafe state.");
   }
 
   // standard takeoff
@@ -1536,6 +1561,7 @@ bool EstimationManager::callbackToggleServiceCallbacks(const std::shared_ptr<std
 
   if (!sm_->isInitialized()) {
     RCLCPP_ERROR(node_->get_logger(), "service for toggling callbacks is not available before initialization.");
+    error_publisher_->addOneshotError("Service for toggling callbacks is not available before initialization.");
     return false;
   }
 
@@ -1635,6 +1661,7 @@ bool EstimationManager::loadConfigFile(const std::string &file_path) {
 
     if (result != 0) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load '%s'", file_path.c_str());
+      error_publisher_->addOneshotError("Failed to load " + file_path + " config file.");
       return false;
     }
   }
@@ -1646,6 +1673,7 @@ bool EstimationManager::loadConfigFile(const std::string &file_path) {
 
     if (result != 0) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load the platform config file '%s'", _platform_config_.c_str());
+      error_publisher_->addOneshotError("Failed to load " + _platform_config_ + " platform config file.");
       return false;
     }
   }

--- a/src/estimation_manager/estimation_manager.cpp
+++ b/src/estimation_manager/estimation_manager.cpp
@@ -471,12 +471,10 @@ EstimationManager::EstimationManager(rclcpp::NodeOptions options) : mrs_lib::Nod
   clock_ = node_->get_clock();
 
   error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "EstimationManager", "main");
-
-
-  cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_timers_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_subs_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_sc_       = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_ss_       = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_timers_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   mrs_lib::SubscriberHandlerOptions shopts;
 

--- a/src/estimation_manager/estimators/agl_estimator.cpp
+++ b/src/estimation_manager/estimators/agl_estimator.cpp
@@ -43,51 +43,61 @@ bool AglEstimator::isCompatibleWithHwApi(const mrs_msgs::msg::HwApiCapabilities:
 
   if (!ph_->param_loader->loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: Could not load all non-optional parameters. Shutting down.", getPrintName().c_str());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("Could not load all non-optional parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   if (requires_gnss && !hw_api_capabilities->produces_gnss) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires gnss but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_imu && !hw_api_capabilities->produces_imu) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires imu but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_distance_sensor && !hw_api_capabilities->produces_distance_sensor) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires distance_sensor but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_altitude && !hw_api_capabilities->produces_altitude) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires altitude but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_magnetometer_heading && !hw_api_capabilities->produces_magnetometer_heading) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires magnetometer_heading but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_position && !hw_api_capabilities->produces_position) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires position but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_orientation && !hw_api_capabilities->produces_orientation) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires orientation but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_velocity && !hw_api_capabilities->produces_velocity) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires velocity but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 
   if (requires_angular_velocity && !hw_api_capabilities->produces_angular_velocity) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: requires angular_velocity but hw api does not provide it.", getPrintName().c_str());
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return false;
   }
 

--- a/src/gain_manager.cpp
+++ b/src/gain_manager.cpp
@@ -18,6 +18,7 @@
 #include <mrs_lib/service_client_handler.h>
 #include <mrs_lib/service_server_handler.h>
 #include <mrs_lib/subscriber_handler.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 #include <rcl_interfaces/srv/set_parameters.hpp>
 
@@ -137,6 +138,10 @@ private:
   // | ------------------------- helpers ------------------------ |
 
   bool stringInVector(const std::string &value, const std::vector<std::string> &vector);
+
+  // | -------------------- error publisher --------------------- |
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
 };
 
 //}
@@ -157,6 +162,8 @@ void GainManager::initialize() {
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "GainManager", "main");
+
   cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -175,35 +182,35 @@ void GainManager::initialize() {
   if (custom_config_path != "") {
     if (!param_loader.addYamlFile(custom_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load custom_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load custom_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (platform_config_path != "") {
     if (!param_loader.addYamlFile(platform_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load platform_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load platform_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (!param_loader.addYamlFileFromParam("private_config")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load private_config");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load private_config.");
+    error_publisher_->flushAndShutdown();
   }
 
   if (!param_loader.addYamlFileFromParam("public_config")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load public_config");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load public_config.");
+    error_publisher_->flushAndShutdown();
   }
 
   if (!param_loader.addYamlFileFromParam("public_gains")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load public_gains");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load public_gains.");
+    error_publisher_->flushAndShutdown();
   }
 
   const std::string yaml_prefix = "mrs_uav_managers/gain_manager/";
@@ -264,8 +271,8 @@ void GainManager::initialize() {
     for (it2 = temp_vector.begin(); it2 != temp_vector.end(); ++it2) {
       if (!stringInVector(*it2, _gain_names_)) {
         RCLCPP_ERROR(node_->get_logger(), "the element '%s' of %s/allowed_gains is not a valid gain!", it2->c_str(), it->c_str());
-        rclcpp::shutdown();
-        exit(1);
+        error_publisher_->addOneshotError("Invalid gain '" + *it2 + "' in " + *it + "/allowed_gains.");
+        error_publisher_->flushAndShutdown();
       }
     }
 
@@ -280,8 +287,8 @@ void GainManager::initialize() {
 
     if (!stringInVector(temp_str, _map_type_allowed_gains_.at(*it))) {
       RCLCPP_ERROR(node_->get_logger(), "the element '%s' of %s/allowed_gains is not a valid gain!", temp_str.c_str(), it->c_str());
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Invalid default gain '" + temp_str + "' for " + *it + ".");
+      error_publisher_->flushAndShutdown();
     }
 
     _map_type_default_gains_.insert(std::pair<std::string, std::string>(*it, temp_str));
@@ -346,8 +353,8 @@ void GainManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "could not load all parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   is_initialized_ = true;
@@ -545,6 +552,7 @@ bool GainManager::setGains(std::string gains_name) {
     for (auto res : response.value()->results) {
       if (!res.successful) {
         RCLCPP_ERROR(node_->get_logger(), "could not set param: %s", res.reason.c_str());
+        error_publisher_->addOneshotError("Could not set param: " + res.reason);
       }
     }
 
@@ -577,6 +585,7 @@ bool GainManager::callbackSetGains(const std::shared_ptr<mrs_msgs::srv::String::
     ss << "missing estimation diagnostics";
 
     RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+    error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
 
     response->message = ss.str();
     response->success = false;
@@ -613,6 +622,7 @@ bool GainManager::callbackSetGains(const std::shared_ptr<mrs_msgs::srv::String::
     ss << "the Se3Controller could not set the gains";
 
     RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+    error_publisher_->addOneshotError("The Se3Controller could not set the gains.");
 
     response->message = ss.str();
     response->success = false;
@@ -721,11 +731,13 @@ void GainManager::timerDiagnostics() {
 
   if (!sh_estimation_diag_.hasMsg()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 10000, "can not do gain management, missing estimator diagnostics!");
+    error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
     return;
   }
 
   if (!sh_control_manager_diag_.hasMsg()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 10000, "can not do gain management, missing control manager diagnostics!");
+    error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
     return;
   }
 

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -43,6 +43,7 @@
 #include <mrs_msgs/srv/validate_path_to_point_srv.hpp>
 
 #include <mrs_lib/safety_zone/static_edges_visualization.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 //}
 
@@ -244,6 +245,10 @@ private:
   double getMaxZ();
   double getMinZ();
 
+  // | -------------------- error publisher --------------------- |
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
+
 }; // class SafetyAreaManager
 
 //}
@@ -254,6 +259,8 @@ SafetyAreaManager::SafetyAreaManager(rclcpp::NodeOptions options) : mrs_lib::Nod
 
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
+
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "SafetyAreaManager", "main");
 
   mrs_lib::ParamLoader param_loader(node_, "SafetyAreaManager");
   param_loader.loadParam("uav_name", _uav_name_);
@@ -306,31 +313,31 @@ void SafetyAreaManager::initialize() {
   if (custom_config_path != "") {
     if (!param_loader.addYamlFile(custom_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load custom_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load custom_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (platform_config_path != "") {
     if (!param_loader.addYamlFile(platform_config_path)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load platform_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load platform_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (_world_config_ != "") {
     if (!param_loader.addYamlFile(_world_config_)) {
       RCLCPP_ERROR(node_->get_logger(), "failed to load world_config");
-      rclcpp::shutdown();
-      exit(1);
+      error_publisher_->addOneshotError("Failed to load world_config.");
+      error_publisher_->flushAndShutdown();
     }
   }
 
   if (!param_loader.addYamlFileFromParam("private_config")) {
     RCLCPP_ERROR(node_->get_logger(), "failed to load private_config");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to load private_config.");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader.loadParam("uav_name", _uav_name_);
@@ -351,8 +358,8 @@ void SafetyAreaManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "could not load all parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader.setPrefix("");
@@ -363,8 +370,8 @@ void SafetyAreaManager::initialize() {
 
   if (!success) {
     RCLCPP_ERROR(node_->get_logger(), "Failed to initialize safety area from file");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Failed to initialize safety area from file.");
+    error_publisher_->flushAndShutdown();
   }
 
   // | ----------------------- publishers ----------------------- |
@@ -522,6 +529,7 @@ void SafetyAreaManager::timerPrerequisites() {
 
   if (!got_hw_api_capabilities) {
     RCLCPP_WARN(node_->get_logger(), "waiting for data: HW Api=%s", got_hw_api_capabilities ? " TRUE " : " FALSE ");
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return;
   }
 
@@ -547,6 +555,7 @@ void SafetyAreaManager::timerStatus() {
 
   if (!got_odom) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 5000, "waiting for data: Odometry=%s", got_odom ? "true" : "FALSE");
+    error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
     return;
   }
 
@@ -635,6 +644,7 @@ void SafetyAreaManager::timerStatus() {
       safety_zone_handler_ = std::move(*new_safety_zone);
     } else {
       RCLCPP_ERROR(node_->get_logger(), "Failed to update safety area after world origin change.");
+      error_publisher_->addOneshotError("Failed to update safety area after world origin change.");
     }
 
     world_origin_changed_ = false;
@@ -825,6 +835,7 @@ bool SafetyAreaManager::callbackSetSafetyBorder(const std::shared_ptr<mrs_msgs::
 
   if (!sh_control_manager_diag_.hasMsg()) {
     RCLCPP_WARN(node_->get_logger(), "No control manager diagnostics received yet.");
+    error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
     response->message = "No control manager diagnostics received yet.";
     response->success = false;
     return true;
@@ -845,6 +856,7 @@ bool SafetyAreaManager::callbackSetSafetyBorder(const std::shared_ptr<mrs_msgs::
 
   if (!success) {
     RCLCPP_WARN(node_->get_logger(), "Failed to set safety border.");
+    error_publisher_->addOneshotError("Failed to set safety border.");
     response->message = "Failed to set border";
     response->success = false;
     return true;
@@ -1179,8 +1191,8 @@ bool SafetyAreaManager::initializationFromFile(mrs_lib::ParamLoader &param_loade
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "could not load world config parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load world config parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   // Make border prism
@@ -1258,6 +1270,7 @@ bool SafetyAreaManager::initializationFromFile(mrs_lib::ParamLoader &param_loade
 
   if (!new_safety_zone) {
     RCLCPP_WARN(node_->get_logger(), "Failed to create new safety zone.");
+    error_publisher_->addOneshotError("Failed to create new safety zone from file.");
     return false;
   }
 
@@ -1319,6 +1332,7 @@ bool SafetyAreaManager::initializationFromMsg(const mrs_msgs::msg::Prism &prism_
 
   if (!new_safety_zone) {
     RCLCPP_WARN(node_->get_logger(), "Failed to create new safety zone.");
+    error_publisher_->addOneshotError("Failed to create new safety zone from message.");
     return false;
   }
 

--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -11,6 +11,7 @@
 #include <mrs_lib/transformer.h>
 #include <mrs_lib/transform_broadcaster.h>
 #include <mrs_lib/gps_conversions.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 #include <mrs_msgs/msg/uav_state.hpp>
 #include <mrs_msgs/msg/float64_stamped.hpp>
@@ -157,6 +158,18 @@ private:
   void publishLocalTf();
 
   void publishAmslTf(const double altitude, const rclcpp::Time &stamp);
+
+  // | -------------------- error publisher --------------------- |
+
+  enum class error_type_t : uint16_t
+  {
+    nans_in_transform,
+    nans_in_utm,
+    nans_in_rtk,
+    transform_failure,
+  };
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
 };
 /*//}*/
 
@@ -175,6 +188,8 @@ void TransformManager::initialize() {
 
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
+
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "TransformManager", "main");
 
   ch_ = std::make_shared<estimation_manager::CommonHandlers_t>();
 
@@ -255,7 +270,8 @@ void TransformManager::initialize() {
   } else {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: mrs_uav_managers/world_origin/units must be (\"UTM\"|\"LATLON\"). Got '%s'", getPrintName().c_str(),
                  world_origin_units_.c_str());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("Invalid world_origin/units: must be 'UTM' or 'LATLON'.");
+    error_publisher_->flushAndShutdown();
   }
 
   world_origin_.x = world_origin_x;
@@ -264,7 +280,8 @@ void TransformManager::initialize() {
 
   if (!is_origin_param_ok) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: Could not load all mandatory parameters from world file. Please check your world file.", getPrintName().c_str());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("Could not load all mandatory parameters from world file.");
+    error_publisher_->flushAndShutdown();
   }
 
   /*//}*/
@@ -469,7 +486,8 @@ void TransformManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: Could not load all non-optional parameters. Shutting down.", getPrintName().c_str());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("Could not load all non-optional parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   // Check if the RTK antenna static tf is defined
@@ -488,7 +506,8 @@ void TransformManager::initialize() {
   if (!got_rtk_antenna_tf) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: The transform from FCU to RTK antenna is not defined. Please provide static tf from %s to %s.",
                  getPrintName().c_str(), ch_->frames.ns_fcu.c_str(), ch_->frames.ns_rtk_antenna.c_str());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("RTK antenna TF not available.");
+    error_publisher_->flushAndShutdown();
   }
 
   is_initialized_ = true;
@@ -563,6 +582,7 @@ void TransformManager::callbackUavState(const mrs_msgs::msg::UavState::ConstShar
       } else {
         RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in transform from %s to %s. Not publishing tf.", getPrintName().c_str(),
                              tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
+        error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in stable_origin transform.");
       }
       RCLCPP_INFO_ONCE(node_->get_logger(), "[%s]: Broadcasting transform from parent frame: %s to child frame: %s", getPrintName().c_str(),
                        tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
@@ -607,6 +627,7 @@ void TransformManager::callbackUavState(const mrs_msgs::msg::UavState::ConstShar
     } else {
       RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in transform from %s to %s. Not publishing tf.", getPrintName().c_str(),
                            tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
+      error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in fixed_origin transform.");
     }
     RCLCPP_INFO_ONCE(node_->get_logger(), "[%s]: Broadcasting transform from parent frame: %s to child frame: %s", getPrintName().c_str(),
                      tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
@@ -697,6 +718,7 @@ void TransformManager::callbackHeightAgl(const mrs_msgs::msg::Float64Stamped::Co
   } else {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in transform from %s to %s. Not publishing tf.", getPrintName().c_str(),
                          tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in height_agl transform.");
   }
   RCLCPP_INFO_ONCE(node_->get_logger(), "[%s]: Broadcasting transform from parent frame: %s to child frame: %s", getPrintName().c_str(),
                    tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
@@ -749,6 +771,7 @@ void TransformManager::publishAmslTf(const double altitude, const rclcpp::Time &
   } else {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in transform from %s to %s. Not publishing tf.", getPrintName().c_str(),
                          tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in AMSL transform.");
   }
   RCLCPP_INFO_ONCE(node_->get_logger(), "[%s]: Broadcasting transform from parent frame: %s to child frame: %s", getPrintName().c_str(),
                    tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
@@ -790,11 +813,13 @@ void TransformManager::callbackGnss(const sensor_msgs::msg::NavSatFix::ConstShar
 
   if (!std::isfinite(out_x)) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in UTM variable \"out_x\"!!!", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_utm, "NaN in UTM out_x.");
     return;
   }
 
   if (!std::isfinite(out_y)) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in UTM variable \"out_y\"!!!", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_utm, "NaN in UTM out_y.");
     return;
   }
 
@@ -836,16 +861,19 @@ void TransformManager::callbackRtkGps(const mrs_msgs::msg::RtkGps::ConstSharedPt
 
   if (!std::isfinite(msg->gps.latitude)) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] NaN detected in RTK variable \"msg->latitude\"!!!", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_rtk, "NaN in RTK latitude.");
     return;
   }
 
   if (!std::isfinite(msg->gps.longitude)) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] NaN detected in RTK variable \"msg->longitude\"!!!", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_rtk, "NaN in RTK longitude.");
     return;
   }
 
   if (!std::isfinite(msg->gps.altitude)) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] NaN detected in RTK variable \"msg->altitude\"!!!", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_rtk, "NaN in RTK altitude.");
     return;
   }
 
@@ -865,6 +893,7 @@ void TransformManager::callbackRtkGps(const mrs_msgs::msg::RtkGps::ConstSharedPt
     rtk_pos.pose = res.value();
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: transform to fcu failed", getPrintName().c_str());
+    error_publisher_->addOneshotError("Transform RTK to FCU failed.");
     return;
   }
 
@@ -971,6 +1000,7 @@ void TransformManager::publishFcuUntiltedTf(const geometry_msgs::msg::Quaternion
     broadcaster_->sendTransform(tf);
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN encountered in fcu_untilted tf", getPrintName().c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in FCU untilted TF.");
   }
   scope_timer.checkpoint("tf pub");
 }
@@ -1004,6 +1034,7 @@ void TransformManager::publishLocalTf() {
   } else {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NaN detected in transform from %s to %s. Not publishing tf.", getPrintName().c_str(),
                          tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
+    error_publisher_->addGeneralError(error_type_t::nans_in_transform, "NaN in local_origin transform.");
   }
   RCLCPP_INFO_ONCE(node_->get_logger(), "[%s]: Broadcasting transform from parent frame: %s to child frame: %s", getPrintName().c_str(),
                    tf_msg.header.frame_id.c_str(), tf_msg.child_frame_id.c_str());
@@ -1025,6 +1056,7 @@ std::optional<geometry_msgs::msg::Pose> TransformManager::transformRtkToFcu(cons
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: Could not obtain transform from %s to %s.", getPrintName().c_str(),
                           ch_->frames.ns_fcu_untilted.c_str(), ch_->frames.ns_fcu.c_str());
+    error_publisher_->addOneshotError("Could not obtain transform from fcu_untilted to fcu.");
     return {};
   }
 
@@ -1046,6 +1078,7 @@ std::optional<geometry_msgs::msg::Pose> TransformManager::transformRtkToFcu(cons
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: Could not transform RTK pose from %s to %s.", getPrintName().c_str(),
                           utm_in_antenna.header.frame_id.c_str(), ch_->frames.ns_fcu.c_str());
+    error_publisher_->addOneshotError("Could not transform RTK pose to FCU frame.");
     return {};
   }
 

--- a/src/uav_manager.cpp
+++ b/src/uav_manager.cpp
@@ -44,6 +44,8 @@
 #include <mrs_lib/geometry/cyclic.h>
 #include <mrs_lib/geometry/misc.h>
 #include <mrs_lib/quadratic_throttle_model.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
+
 
 //}
 
@@ -110,6 +112,9 @@ private:
 
   bool        is_initialized_ = false;
   std::string _uav_name_;
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
+
 
 public:
   std::shared_ptr<mrs_lib::Transformer> transformer_;
@@ -343,6 +348,8 @@ UavManager::UavManager(rclcpp::NodeOptions options) : mrs_lib::Node("uav_manager
   node_  = this_node_ptr();
   clock_ = node_->get_clock();
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "UavManager", "main");
+
   cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -449,8 +456,8 @@ void UavManager::initialize() {
 
   if (_takeoff_height_ < 0.5 || _takeoff_height_ > 10.0) {
     RCLCPP_ERROR(node_->get_logger(), "the takeoff height (%.2f m) has to be between 0.5 and 10 meters", _takeoff_height_);
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("The takeoff height has to be between 0.5 and 10 meters.");
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader.loadParam(yaml_prefix + "landing/rate", _landing_timer_rate_);
@@ -508,8 +515,8 @@ void UavManager::initialize() {
 
   if (!param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "Could not load all parameters!");
-    rclcpp::shutdown();
-    exit(1);
+    error_publisher_->addOneshotError("Could not load all parameters.");
+    error_publisher_->flushAndShutdown();
   }
 
   // | --------------------- tf transformer --------------------- |
@@ -734,6 +741,7 @@ void UavManager::timerHwApiCapabilities() {
 
   if (!sh_hw_api_capabilities_.hasMsg()) {
     RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for HW API capabilities");
+    error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
     return;
   }
 
@@ -781,6 +789,7 @@ void UavManager::timerLanding() {
   } else {
 
     RCLCPP_ERROR(node_->get_logger(), "could not transform the reference into the current frame! land by yourself pls.");
+    error_publisher_->addOneshotError("Could not transform the landing reference into the current frame. Perform manual landing.");
     return;
   }
 
@@ -801,6 +810,7 @@ void UavManager::timerLanding() {
     }
     catch (mrs_lib::AttitudeConverter::GetHeadingException &e) {
       RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "exception caught: '%s'", e.what());
+      error_publisher_->addOneshotError("Could not get heading from landing reference orientation.");
       return;
     }
 
@@ -812,6 +822,7 @@ void UavManager::timerLanding() {
       if (!success) {
 
         RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "call for landing failed: '%s'", message.c_str());
+        error_publisher_->addOneshotError("Call for landing failed: " + message);
       }
 
     } else if (!control_manager_diagnostics->tracker_status.have_goal && control_manager_diagnostics->flying_normally) {
@@ -844,6 +855,7 @@ void UavManager::timerLanding() {
           std::stringstream ss;
           ss << "could not transform current height to " << land_there_reference_.header.frame_id;
           RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+          error_publisher_->addOneshotError(ss.str());
         }
 
         reference_out.header.frame_id = land_there_reference_.header.frame_id;
@@ -979,6 +991,8 @@ void UavManager::timerTakeoff() {
     } else {
 
       RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for takeoff confirmation from the ControlManager");
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
+
       return;
     }
   }
@@ -995,6 +1009,7 @@ void UavManager::timerTakeoff() {
       }
       catch (mrs_lib::AttitudeConverter::GetHeadingException &e) {
         RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "exception caught: '%s'", e.what());
+        error_publisher_->addOneshotError("Could not get heading during takeoff.");
         return;
       }
       // this is needed for land_home to work with vins_kickoff estimator
@@ -1036,6 +1051,22 @@ void UavManager::timerMaxHeight() {
 
   if (!sh_max_height_.hasMsg() || !sh_height_.hasMsg() || !sh_control_manager_diag_.hasMsg() || !sh_odometry_.hasMsg()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 10000, "maxHeightTimer() not spinning, missing data");
+
+    if (!sh_max_height_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
+    }
+
+    if (!sh_height_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
+    }
+
+    if (!sh_control_manager_diag_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
+    }
+
+    if (!sh_odometry_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
+    }
     return;
   }
 
@@ -1072,6 +1103,7 @@ void UavManager::timerMaxHeight() {
   }
   catch (mrs_lib::AttitudeConverter::GetHeadingException &e) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "exception caught: '%s'", e.what());
+    error_publisher_->addOneshotError("Could not get heading during max height checking.");
     return;
   }
 
@@ -1102,7 +1134,7 @@ void UavManager::timerMaxHeight() {
     } else {
 
       RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "could not descend");
-
+      error_publisher_->addOneshotError("Could not descend during max height checking.");
       setControlCallbacksSrv(true);
     }
   }
@@ -1134,6 +1166,19 @@ void UavManager::timerMinHeight() {
 
   if (!sh_odometry_.hasMsg() || !sh_height_.hasMsg() || !sh_control_manager_diag_.hasMsg() || !sh_odometry_.hasMsg()) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 10000, "minHeightTimer() not spinning, missing data");
+
+    if (!sh_height_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
+    }
+
+    if (!sh_control_manager_diag_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
+    }
+
+    if (!sh_odometry_.hasMsg()) {
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
+    }
+
     return;
   }
 
@@ -1155,6 +1200,7 @@ void UavManager::timerMinHeight() {
   }
   catch (mrs_lib::AttitudeConverter::GetHeadingException &e) {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "exception caught: '%s'", e.what());
+    error_publisher_->addOneshotError("Could not get heading during min height checking.");
     return;
   }
 
@@ -1291,6 +1337,7 @@ void UavManager::timerMaxthrottle() {
 
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "throttle over threshold (%.2f/%.2f) for more than %.2f s, calling for emergency landing",
                           desired_throttle, _maxthrottle_max_throttle_, _maxthrottle_eland_timeout_);
+    error_publisher_->addOneshotError("Maxthrottle timer: throttle over threshold for too long, calling for emergency landing.");
 
     elandSrv();
   }
@@ -1392,6 +1439,7 @@ void UavManager::timerMidairActivation() {
       if (!controller_switched) {
 
         RCLCPP_ERROR(node_->get_logger(), "could not activate '%s'", _midair_activation_after_controller_.c_str());
+        error_publisher_->addOneshotError("Could not activate controller '" + _midair_activation_after_controller_ + "' after midair activation.");
 
         ehoverSrv();
 
@@ -1407,6 +1455,7 @@ void UavManager::timerMidairActivation() {
       if (!tracker_switched) {
 
         RCLCPP_ERROR(node_->get_logger(), "could not activate '%s'", _midair_activation_after_tracker_.c_str());
+        error_publisher_->addOneshotError("Could not activate tracker '" + _midair_activation_after_tracker_ + "' after midair activation.");
 
         ehoverSrv();
 
@@ -1424,6 +1473,7 @@ void UavManager::timerMidairActivation() {
   if ((clock_->now() - midair_activation_started_).seconds() > 0.5) {
 
     RCLCPP_ERROR(node_->get_logger(), "waiting for OFFBOARD timeouted, reverting");
+    error_publisher_->addOneshotError("Waiting for OFFBOARD during midair activation timeouted, reverting to ehover.");
 
     toggleControlOutput(false);
 
@@ -1491,6 +1541,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (!sh_odometry_.hasMsg()) {
       ss << "can not takeoff, missing odometry!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1499,6 +1550,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (!sh_hw_api_status_.hasMsg() || (clock_->now() - sh_hw_api_status_.lastMsgTime()).seconds() > 5.0) {
       ss << "can not takeoff, missing HW API status!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"HwApiManager", "main"});
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1507,6 +1559,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (!sh_hw_api_status_.getMsg()->armed) {
       ss << "can not takeoff, UAV not armed!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Cannot takeoff, UAV not armed!");
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1515,6 +1568,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (!sh_hw_api_status_.getMsg()->offboard) {
       ss << "can not takeoff, UAV not in offboard mode!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Cannot takeoff, UAV not in OFFBOARD mode!");
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1524,6 +1578,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
       if (!sh_control_manager_diag_.hasMsg() && (clock_->now() - sh_control_manager_diag_.lastMsgTime()).seconds() > 5.0) {
         ss << "can not takeoff, missing control manager diagnostics!";
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
         response->message = ss.str();
         response->success = false;
         return true;
@@ -1532,6 +1587,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
       if (_null_tracker_name_ != sh_control_manager_diag_.getMsg()->active_tracker) {
         ss << "can not takeoff, need '" << _null_tracker_name_ << "' to be active!";
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addOneshotError("Cannot takeoff, NullTracker is not active!");
         response->message = ss.str();
         response->success = false;
         return true;
@@ -1541,6 +1597,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (!sh_controller_diagnostics_.hasMsg()) {
       ss << "can not takeoff, missing controller diagnostics!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1549,6 +1606,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (_gain_manager_required_ && (!sh_gains_diag_.hasMsg() || (clock_->now() - sh_gains_diag_.lastMsgTime()).seconds() > 5.0)) {
       ss << "can not takeoff, GainManager is not running!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"GainManager", "main"});
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1557,6 +1615,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
     if (_constraint_manager_required_ && (!sh_constraints_diag_.hasMsg() || (clock_->now() - sh_constraints_diag_.lastMsgTime()).seconds() > 5.0)) {
       ss << "can not takeoff, ConstraintManager is not running!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ConstraintManager", "main"});
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1566,6 +1625,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
 
       ss << "can not takeoff, Control Manager's output is disabled!";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Cannot takeoff, Control Manager's output is disabled!");
       response->message = ss.str();
       response->success = false;
       return true;
@@ -1580,6 +1640,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
         ss << std::setprecision(2);
         ss << "can not takeoff, estimated mass difference is too large: " << _null_tracker_name_ << "!";
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addOneshotError("Cannot takeoff, estimated mass difference is too large in " + _null_tracker_name_ + "!");
         response->message = ss.str();
         response->success = false;
         return true;
@@ -1625,6 +1686,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
       std::stringstream ss;
       ss << "could not activate '" << _takeoff_controller_name_ << "' for takeoff";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _takeoff_controller_name_ + "' for takeoff.");
       response->success = false;
       response->message = ss.str();
 
@@ -1646,6 +1708,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
       std::stringstream ss;
       ss << "could not activate '" << _takeoff_tracker_name_ << "' for takeoff";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _takeoff_tracker_name_ + "' for takeoff.");
       response->success = false;
       response->message = ss.str();
 
@@ -1704,6 +1767,7 @@ bool UavManager::callbackTakeoff([[maybe_unused]] const std::shared_ptr<std_srvs
       std::stringstream ss;
       ss << "takeoff was not successful";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Takeoff service call was not successful.");
       response->success = false;
       response->message = ss.str();
 
@@ -1738,6 +1802,7 @@ bool UavManager::callbackLand([[maybe_unused]] const std::shared_ptr<std_srvs::s
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
       return true;
     }
 
@@ -1747,12 +1812,14 @@ bool UavManager::callbackLand([[maybe_unused]] const std::shared_ptr<std_srvs::s
         response->message = ss.str();
         response->success = false;
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
         return true;
       }
 
       if (_null_tracker_name_ == sh_control_manager_diag_.getMsg()->active_tracker) {
         ss << "can not land, '" << _null_tracker_name_ << "' is active!";
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addOneshotError("Cannot land, NullTracker is active!");
         response->message = ss.str();
         response->success = false;
         return true;
@@ -1764,6 +1831,7 @@ bool UavManager::callbackLand([[maybe_unused]] const std::shared_ptr<std_srvs::s
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
       return true;
     }
 
@@ -1772,6 +1840,7 @@ bool UavManager::callbackLand([[maybe_unused]] const std::shared_ptr<std_srvs::s
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
       return true;
     }
   }
@@ -1817,6 +1886,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"EstimationManager", "main"});
       return true;
     }
 
@@ -1826,12 +1896,14 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
         response->message = ss.str();
         response->success = false;
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
         return true;
       }
 
       if (_null_tracker_name_ == sh_control_manager_diag_.getMsg()->active_tracker) {
         ss << "can not land, '" << _null_tracker_name_ << "' is active!";
         RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+        error_publisher_->addOneshotError("Cannot land home, NullTracker is active!");
         response->message = ss.str();
         response->success = false;
         return true;
@@ -1843,6 +1915,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
       return true;
     }
 
@@ -1851,6 +1924,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addWaitingForNodeError({"ControlManager", "main"});
       return true;
     }
 
@@ -1859,6 +1933,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Cannot land home, descending to safe height!");
       return true;
     }
 
@@ -1867,6 +1942,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
       response->message = ss.str();
       response->success = false;
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Cannot land home, already landing!");
       return true;
     }
   }
@@ -1943,6 +2019,7 @@ bool UavManager::callbackLandHome([[maybe_unused]] const std::shared_ptr<std_srv
     std::stringstream ss;
     ss << "can not fly home for landing";
     RCLCPP_ERROR_STREAM(node_->get_logger(), "" << ss.str());
+    error_publisher_->addOneshotError("Could not fly home for landing.");
 
     response->success = false;
     response->message = ss.str();
@@ -2250,6 +2327,7 @@ std::tuple<bool, std::string> UavManager::landImpl(void) {
       std::stringstream ss;
       ss << "could not activate '" << _takeoff_controller_name_ << "' for landing";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _takeoff_controller_name_ + "' for landing.");
 
       elandSrv();
 
@@ -2270,6 +2348,7 @@ std::tuple<bool, std::string> UavManager::landImpl(void) {
       std::stringstream ss;
       ss << "could not activate '" << _takeoff_tracker_name_ << "' for landing";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _takeoff_tracker_name_ + "' for landing.");
 
       elandSrv();
 
@@ -2319,6 +2398,7 @@ std::tuple<bool, std::string> UavManager::landImpl(void) {
       std::stringstream ss;
       ss << "could not land";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not land.");
 
       elandSrv();
 
@@ -2410,6 +2490,7 @@ std::tuple<bool, std::string> UavManager::midairActivationImpl(void) {
       std::stringstream ss;
       ss << "could not activate '" << _midair_activation_during_controller_ << "' for midair activation";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _midair_activation_during_controller_ + "' for midair activation.");
 
       return std::tuple(false, ss.str());
     }
@@ -2426,6 +2507,7 @@ std::tuple<bool, std::string> UavManager::midairActivationImpl(void) {
       std::stringstream ss;
       ss << "could not enable Control Manager's output";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not enable Control Manager's output.");
 
       return std::tuple(false, ss.str());
     }
@@ -2447,6 +2529,7 @@ std::tuple<bool, std::string> UavManager::midairActivationImpl(void) {
       std::stringstream ss;
       ss << "could not activate '" << _midair_activation_during_tracker_ << "' for midair activation";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate '" + _midair_activation_during_tracker_ + "' for midair activation.");
 
       return std::tuple(false, ss.str());
     }
@@ -2469,6 +2552,7 @@ std::tuple<bool, std::string> UavManager::midairActivationImpl(void) {
       std::stringstream ss;
       ss << "could not activate offboard mode";
       RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *clock_, 1000, "" << ss.str());
+      error_publisher_->addOneshotError("Could not activate offboard mode.");
 
       return std::tuple(false, ss.str());
     }

--- a/src/uav_manager.cpp
+++ b/src/uav_manager.cpp
@@ -110,11 +110,9 @@ private:
   rclcpp::TimerBase::SharedPtr timer_preinitialization_;
   void                         timerPreInitialization();
 
-  bool        is_initialized_ = false;
-  std::string _uav_name_;
-
+  bool                                                 is_initialized_ = false;
+  std::string                                          _uav_name_;
   std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
-
 
 public:
   std::shared_ptr<mrs_lib::Transformer> transformer_;
@@ -349,11 +347,10 @@ UavManager::UavManager(rclcpp::NodeOptions options) : mrs_lib::Node("uav_manager
   clock_ = node_->get_clock();
 
   error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "UavManager", "main");
-
-  cbkgrp_subs_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_ss_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_sc_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cbkgrp_timers_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_subs_     = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_ss_       = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_sc_       = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cbkgrp_timers_   = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   mrs_lib::SubscriberHandlerOptions shopts;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ endfunction()
 
 add_subdirectory(constraint_manager)
 add_subdirectory(control_manager)
+add_subdirectory(errorgraph)
 add_subdirectory(estimation_manager)
 add_subdirectory(gain_manager)
 add_subdirectory(uav_manager)

--- a/test/errorgraph/CMakeLists.txt
+++ b/test/errorgraph/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(errorgraph_managers_report_waiting)
+add_subdirectory(errorgraph_managers_clear_after_startup)

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/CMakeLists.txt
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+add_mrs_uav_managers_test_target("${TEST_NAME}")

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/config/mrs_simulator.yaml
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/config/mrs_simulator.yaml
@@ -1,0 +1,10 @@
+individual_takeoff_platform:
+  enabled: false
+
+uav1:
+  type: "x500"
+  spawn:
+    x: 10.0
+    y: 20.0
+    z: 0.5
+    heading: 1.2

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
@@ -1,0 +1,155 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+
+#include <mrs_uav_testing/test_generic.h>
+#include <mrs_msgs/msg/errorgraph_element.hpp>
+#include <mrs_msgs/msg/errorgraph_error.hpp>
+
+#include <mutex>
+#include <vector>
+#include <string>
+#include <optional>
+
+using namespace std::chrono_literals;
+
+class Tester : public mrs_uav_testing::TestGeneric {
+
+public:
+  Tester();
+
+  bool test(void);
+
+private:
+  struct TopicState {
+    rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
+    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
+    int consecutive_clean = 0;
+  };
+
+  std::mutex mtx_;
+  std::vector<TopicState> topics_;
+
+  const std::vector<std::string> topic_names_ = {
+      "/uav1/estimation_manager/errors",
+      "/uav1/control_manager/errors",
+      "/uav1/uav_manager/errors",
+  };
+
+  const std::vector<std::string> expected_source_nodes_ = {
+      "EstimationManager",
+      "ControlManager",
+      "UavManager",
+  };
+
+  void errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
+};
+
+Tester::Tester() : mrs_uav_testing::TestGeneric() {
+
+  topics_.resize(topic_names_.size());
+
+  for (size_t i = 0; i < topic_names_.size(); i++) {
+    topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
+        topic_names_[i], 100,
+        [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+  }
+}
+
+void Tester::errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
+  std::scoped_lock lck(mtx_);
+  topics_[idx].last_msg = *msg;
+}
+
+bool Tester::test(void) {
+
+  RCLCPP_INFO(node_->get_logger(), "Waiting for all 3 managers' errorgraph errors to clear after startup...");
+
+  const double timeout_s = 90.0;
+  const double poll_rate_s = 0.2;
+  const int required_consecutive_clean = 3;
+
+  double elapsed = 0.0;
+
+  while (rclcpp::ok() && elapsed < timeout_s) {
+
+    sleep(poll_rate_s);
+    elapsed += poll_rate_s;
+
+    std::scoped_lock lck(mtx_);
+
+    bool all_cleared = true;
+
+    for (size_t i = 0; i < topics_.size(); i++) {
+
+      if (topics_[i].consecutive_clean >= required_consecutive_clean) {
+        continue;  // already cleared
+      }
+
+      if (!topics_[i].last_msg.has_value()) {
+        all_cleared = false;
+        continue;
+      }
+
+      const auto& element = topics_[i].last_msg.value();
+
+      if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
+        all_cleared = false;
+        continue;
+      }
+
+      bool has_waiting_for_node = false;
+      for (const auto& error : element.errors) {
+        if (error.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_NODE) {
+          has_waiting_for_node = true;
+          break;
+        }
+      }
+
+      if (!has_waiting_for_node) {
+        topics_[i].consecutive_clean++;
+        RCLCPP_INFO(node_->get_logger(), "%s: clean message %d/%d",
+                     expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean, required_consecutive_clean);
+      } else {
+        topics_[i].consecutive_clean = 0;
+      }
+
+      if (topics_[i].consecutive_clean < required_consecutive_clean) {
+        all_cleared = false;
+      }
+    }
+
+    if (all_cleared) {
+      RCLCPP_INFO(node_->get_logger(), "SUCCESS: all 3 managers' errorgraph errors cleared after startup.");
+      return true;
+    }
+  }
+
+  // Report which topics didn't clear
+  for (size_t i = 0; i < topics_.size(); i++) {
+    if (topics_[i].consecutive_clean < required_consecutive_clean) {
+      RCLCPP_ERROR(node_->get_logger(), "FAILED: %s did not clear (consecutive_clean=%d/%d)",
+                   expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean, required_consecutive_clean);
+    }
+  }
+
+  return false;
+}
+
+int main(int argc, char* argv[]) {
+
+  rclcpp::init(argc, argv);
+
+  bool test_result = true;
+
+  Tester tester;
+
+  test_result &= tester.test();
+
+  tester.sleep(2.0);
+
+  std::cout << "Test: reporting test results" << std::endl;
+
+  tester.reportTestResult(test_result);
+
+  tester.join();
+}

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
@@ -5,6 +5,7 @@
 #include <mrs_msgs/msg/errorgraph_element.hpp>
 #include <mrs_msgs/msg/errorgraph_error.hpp>
 
+#include <map>
 #include <mutex>
 #include <vector>
 #include <string>
@@ -20,44 +21,42 @@ public:
   bool test(void);
 
 private:
-  struct TopicState
+  struct ManagerState
   {
-    rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
-    std::optional<mrs_msgs::msg::ErrorgraphElement>                   last_msg;
-    int                                                               consecutive_clean = 0;
+    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
+    int                                             consecutive_clean = 0;
   };
 
-  std::mutex              mtx_;
-  std::vector<TopicState> topics_;
+  std::mutex                          mtx_;
+  std::map<std::string, ManagerState> manager_states_;
 
-  const std::vector<std::string> topic_names_ = {
-      "/uav1/estimation_manager/errors",
-      "/uav1/control_manager/errors",
-      "/uav1/uav_manager/errors",
-  };
+  rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub_;
+
+  const std::string topic_name_ = "/uav1/errors";
 
   const std::vector<std::string> expected_source_nodes_ = {
-      "EstimationManager",
-      "ControlManager",
-      "UavManager",
+      "EstimationManager", "SafetyAreaManager", "TransformManager", "ConstraintManager", "GainManager", "ControlManager", "UavManager",
   };
 
-  void errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
+  void errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
 };
 
 Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
-  topics_.resize(topic_names_.size());
-
-  for (size_t i = 0; i < topic_names_.size(); i++) {
-    topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
-        topic_names_[i], 100, [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+  for (const auto &name : expected_source_nodes_) {
+    manager_states_[name] = ManagerState{};
   }
+
+  sub_ = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(topic_name_, 100,
+                                                                      [this](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(msg); });
 }
 
-void Tester::errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
+void Tester::errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
   std::scoped_lock lck(mtx_);
-  topics_[idx].last_msg = *msg;
+  auto             it = manager_states_.find(msg->source_node.node);
+  if (it != manager_states_.end()) {
+    it->second.last_msg = *msg;
+  }
 }
 
 bool Tester::test(void) {
@@ -79,20 +78,20 @@ bool Tester::test(void) {
 
     bool all_cleared = true;
 
-    for (size_t i = 0; i < topics_.size(); i++) {
+    for (auto &[name, state] : manager_states_) {
 
-      if (topics_[i].consecutive_clean >= required_consecutive_clean) {
+      if (state.consecutive_clean >= required_consecutive_clean) {
         continue; // already cleared
       }
 
-      if (!topics_[i].last_msg.has_value()) {
+      if (!state.last_msg.has_value()) {
         all_cleared = false;
         continue;
       }
 
-      const auto &element = topics_[i].last_msg.value();
+      const auto &element = state.last_msg.value();
 
-      if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
+      if (element.source_node.node != name || element.source_node.component != "main") {
         all_cleared = false;
         continue;
       }
@@ -106,14 +105,13 @@ bool Tester::test(void) {
       }
 
       if (!has_waiting_for_node) {
-        topics_[i].consecutive_clean++;
-        RCLCPP_INFO(node_->get_logger(), "%s: clean message %d/%d", expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean,
-                    required_consecutive_clean);
+        state.consecutive_clean++;
+        RCLCPP_INFO(node_->get_logger(), "%s: clean message %d/%d", name.c_str(), state.consecutive_clean, required_consecutive_clean);
       } else {
-        topics_[i].consecutive_clean = 0;
+        state.consecutive_clean = 0;
       }
 
-      if (topics_[i].consecutive_clean < required_consecutive_clean) {
+      if (state.consecutive_clean < required_consecutive_clean) {
         all_cleared = false;
       }
     }
@@ -124,10 +122,10 @@ bool Tester::test(void) {
     }
   }
 
-  // Report which topics didn't clear
-  for (size_t i = 0; i < topics_.size(); i++) {
-    if (topics_[i].consecutive_clean < required_consecutive_clean) {
-      RCLCPP_ERROR(node_->get_logger(), "FAILED: %s did not clear (consecutive_clean=%d/%d)", expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean,
+  // Report which managers didn't clear
+  for (const auto &[name, state] : manager_states_) {
+    if (state.consecutive_clean < required_consecutive_clean) {
+      RCLCPP_ERROR(node_->get_logger(), "FAILED: %s did not clear (consecutive_clean=%d/%d)", name.c_str(), state.consecutive_clean,
                    required_consecutive_clean);
     }
   }

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/test.cpp
@@ -20,13 +20,14 @@ public:
   bool test(void);
 
 private:
-  struct TopicState {
+  struct TopicState
+  {
     rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
-    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
-    int consecutive_clean = 0;
+    std::optional<mrs_msgs::msg::ErrorgraphElement>                   last_msg;
+    int                                                               consecutive_clean = 0;
   };
 
-  std::mutex mtx_;
+  std::mutex              mtx_;
   std::vector<TopicState> topics_;
 
   const std::vector<std::string> topic_names_ = {
@@ -50,8 +51,7 @@ Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
   for (size_t i = 0; i < topic_names_.size(); i++) {
     topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
-        topic_names_[i], 100,
-        [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+        topic_names_[i], 100, [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
   }
 }
 
@@ -64,9 +64,9 @@ bool Tester::test(void) {
 
   RCLCPP_INFO(node_->get_logger(), "Waiting for all 3 managers' errorgraph errors to clear after startup...");
 
-  const double timeout_s = 90.0;
-  const double poll_rate_s = 0.2;
-  const int required_consecutive_clean = 3;
+  const double timeout_s                  = 90.0;
+  const double poll_rate_s                = 0.2;
+  const int    required_consecutive_clean = 3;
 
   double elapsed = 0.0;
 
@@ -82,7 +82,7 @@ bool Tester::test(void) {
     for (size_t i = 0; i < topics_.size(); i++) {
 
       if (topics_[i].consecutive_clean >= required_consecutive_clean) {
-        continue;  // already cleared
+        continue; // already cleared
       }
 
       if (!topics_[i].last_msg.has_value()) {
@@ -90,7 +90,7 @@ bool Tester::test(void) {
         continue;
       }
 
-      const auto& element = topics_[i].last_msg.value();
+      const auto &element = topics_[i].last_msg.value();
 
       if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
         all_cleared = false;
@@ -98,7 +98,7 @@ bool Tester::test(void) {
       }
 
       bool has_waiting_for_node = false;
-      for (const auto& error : element.errors) {
+      for (const auto &error : element.errors) {
         if (error.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_NODE) {
           has_waiting_for_node = true;
           break;
@@ -107,8 +107,8 @@ bool Tester::test(void) {
 
       if (!has_waiting_for_node) {
         topics_[i].consecutive_clean++;
-        RCLCPP_INFO(node_->get_logger(), "%s: clean message %d/%d",
-                     expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean, required_consecutive_clean);
+        RCLCPP_INFO(node_->get_logger(), "%s: clean message %d/%d", expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean,
+                    required_consecutive_clean);
       } else {
         topics_[i].consecutive_clean = 0;
       }
@@ -127,15 +127,15 @@ bool Tester::test(void) {
   // Report which topics didn't clear
   for (size_t i = 0; i < topics_.size(); i++) {
     if (topics_[i].consecutive_clean < required_consecutive_clean) {
-      RCLCPP_ERROR(node_->get_logger(), "FAILED: %s did not clear (consecutive_clean=%d/%d)",
-                   expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean, required_consecutive_clean);
+      RCLCPP_ERROR(node_->get_logger(), "FAILED: %s did not clear (consecutive_clean=%d/%d)", expected_source_nodes_[i].c_str(), topics_[i].consecutive_clean,
+                   required_consecutive_clean);
     }
   }
 
   return false;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
   rclcpp::init(argc, argv);
 

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/test.py
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/test.py
@@ -18,9 +18,10 @@ from std_msgs.msg import Bool
 
 def generate_test_description():
 
-    SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp')
 
     ld = launch.LaunchDescription()
+
+    ld.add_action(SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'))
 
     uav_type="x500"
     uav_name="uav1"

--- a/test/errorgraph/errorgraph_managers_clear_after_startup/test.py
+++ b/test/errorgraph/errorgraph_managers_clear_after_startup/test.py
@@ -1,0 +1,152 @@
+import time
+import unittest
+import os
+import sys
+
+import launch
+import launch_ros
+import launch_testing.actions
+import launch_testing.asserts
+from launch.actions import IncludeLaunchDescription, GroupAction, SetEnvironmentVariable
+import rclpy
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
+
+from std_msgs.msg import Bool
+
+def generate_test_description():
+
+    SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp')
+
+    ld = launch.LaunchDescription()
+
+    uav_type="x500"
+    uav_name="uav1"
+    platform_config=get_package_share_directory("mrs_multirotor_simulator")+"/config/mrs_uav_system/"+uav_type+".yaml"
+
+    launch_file_path = os.path.abspath(__file__)
+    launch_dir = os.path.dirname(launch_file_path)
+
+    test_name = os.path.basename(launch_dir)
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                        'launch',
+                        'mrs_uav_system.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'run_automatic_start': "true",
+                        'uav_name': uav_name,
+                        'platform_config': platform_config,
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                            'launch',
+                            'mrs_multirotor_simulator.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'custom_config': launch_dir+"/config/mrs_simulator.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_multirotor_simulator'),
+                            'launch',
+                            'hw_api.launch.py'
+                        ])
+                    ]),
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+            launch_ros.actions.Node(
+                package='mrs_uav_managers',
+                namespace='',
+                executable='test_'+test_name,
+                name='test_'+test_name,
+                output="screen",
+                parameters=[
+                        {'test_name': test_name},
+                ],
+            )
+        )
+
+    ld.add_action(
+        launch.actions.TimerAction(
+            period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        )
+
+    return ld
+
+class PublisherHandlerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('integration_test_handler')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_interactor(self, proc_output, timeout=120):
+
+        """Check whether pose messages published"""
+
+        test_result = []
+
+        sub = self.node.create_subscription(
+                Bool, '/test_result',
+                lambda msg: test_result.append(msg), 100)
+        try:
+
+            end_time = time.time() + timeout
+
+            while time.time() < end_time:
+
+                if len(test_result) > 0:
+                    break
+
+                rclpy.spin_once(self.node, timeout_sec=1)
+
+            time.sleep(2.0)
+
+            # check if we have the result
+            self.assertTrue(len(test_result) > 0)
+
+            # check if the result is true
+            self.assertTrue(test_result[0].data)
+
+        finally:
+            self.node.destroy_subscription(sub)

--- a/test/errorgraph/errorgraph_managers_report_waiting/CMakeLists.txt
+++ b/test/errorgraph/errorgraph_managers_report_waiting/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+add_mrs_uav_managers_test_target("${TEST_NAME}")

--- a/test/errorgraph/errorgraph_managers_report_waiting/config/mrs_simulator.yaml
+++ b/test/errorgraph/errorgraph_managers_report_waiting/config/mrs_simulator.yaml
@@ -1,0 +1,10 @@
+individual_takeoff_platform:
+  enabled: false
+
+uav1:
+  type: "x500"
+  spawn:
+    x: 10.0
+    y: 20.0
+    z: 0.5
+    heading: 1.2

--- a/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
+++ b/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
@@ -5,6 +5,7 @@
 #include <mrs_msgs/msg/errorgraph_element.hpp>
 #include <mrs_msgs/msg/errorgraph_error.hpp>
 
+#include <map>
 #include <mutex>
 #include <vector>
 #include <string>
@@ -21,27 +22,21 @@ public:
   bool test(void);
 
 private:
-  struct TopicState
+  struct ManagerState
   {
-    rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
-    std::optional<mrs_msgs::msg::ErrorgraphElement>                   last_msg;
-    bool                                                              saw_waiting_error = false;
+    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
+    bool                                            saw_waiting_error = false;
   };
 
-  std::mutex              mtx_;
-  std::vector<TopicState> topics_;
+  std::mutex                          mtx_;
+  std::map<std::string, ManagerState> manager_states_;
 
-  // Expected source_node names and their known dependencies
-  const std::vector<std::string> topic_names_ = {
-      "/uav1/estimation_manager/errors",
-      "/uav1/control_manager/errors",
-      "/uav1/uav_manager/errors",
-  };
+  rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub_;
+
+  const std::string topic_name_ = "/uav1/errors";
 
   const std::vector<std::string> expected_source_nodes_ = {
-      "EstimationManager",
-      "ControlManager",
-      "UavManager",
+      "EstimationManager", "SafetyAreaManager", "TransformManager", "ConstraintManager", "GainManager", "ControlManager", "UavManager",
   };
 
   const std::set<std::string> known_dependencies_ = {
@@ -50,22 +45,25 @@ private:
       "EstimationManager",
   };
 
-  void errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
+  void errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
 };
 
 Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
-  topics_.resize(topic_names_.size());
-
-  for (size_t i = 0; i < topic_names_.size(); i++) {
-    topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
-        topic_names_[i], 100, [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+  for (const auto &name : expected_source_nodes_) {
+    manager_states_[name] = ManagerState{};
   }
+
+  sub_ = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(topic_name_, 100,
+                                                                      [this](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(msg); });
 }
 
-void Tester::errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
+void Tester::errorsCallback(const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
   std::scoped_lock lck(mtx_);
-  topics_[idx].last_msg = *msg;
+  auto             it = manager_states_.find(msg->source_node.node);
+  if (it != manager_states_.end()) {
+    it->second.last_msg = *msg;
+  }
 }
 
 bool Tester::test(void) {
@@ -84,16 +82,16 @@ bool Tester::test(void) {
 
     std::scoped_lock lck(mtx_);
 
-    for (size_t i = 0; i < topics_.size(); i++) {
+    for (auto &[name, state] : manager_states_) {
 
-      if (!topics_[i].last_msg.has_value()) {
+      if (!state.last_msg.has_value()) {
         continue;
       }
 
-      const auto &element = topics_[i].last_msg.value();
+      const auto &element = state.last_msg.value();
 
       // Verify the source_node matches what we expect
-      if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
+      if (element.source_node.node != name || element.source_node.component != "main") {
         continue;
       }
 
@@ -102,16 +100,16 @@ bool Tester::test(void) {
 
           // Verify waited_for_node is a known dependency
           if (known_dependencies_.count(error.waited_for_node.node) > 0) {
-            topics_[i].saw_waiting_error = true;
-            RCLCPP_INFO(node_->get_logger(), "%s is waiting for node: %s", expected_source_nodes_[i].c_str(), error.waited_for_node.node.c_str());
+            state.saw_waiting_error = true;
+            RCLCPP_INFO(node_->get_logger(), "%s is waiting for node: %s", name.c_str(), error.waited_for_node.node.c_str());
           }
         }
       }
     }
 
     // Check if at least one manager reported waiting errors
-    for (const auto &t : topics_) {
-      if (t.saw_waiting_error) {
+    for (const auto &[name, state] : manager_states_) {
+      if (state.saw_waiting_error) {
         RCLCPP_INFO(node_->get_logger(), "SUCCESS: at least one manager reported waiting_for_node errors during startup.");
         return true;
       }

--- a/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
+++ b/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
@@ -1,0 +1,144 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+
+#include <mrs_uav_testing/test_generic.h>
+#include <mrs_msgs/msg/errorgraph_element.hpp>
+#include <mrs_msgs/msg/errorgraph_error.hpp>
+
+#include <mutex>
+#include <vector>
+#include <string>
+#include <optional>
+#include <set>
+
+using namespace std::chrono_literals;
+
+class Tester : public mrs_uav_testing::TestGeneric {
+
+public:
+  Tester();
+
+  bool test(void);
+
+private:
+  struct TopicState {
+    rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
+    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
+    bool saw_waiting_error = false;
+  };
+
+  std::mutex mtx_;
+  std::vector<TopicState> topics_;
+
+  // Expected source_node names and their known dependencies
+  const std::vector<std::string> topic_names_ = {
+      "/uav1/estimation_manager/errors",
+      "/uav1/control_manager/errors",
+      "/uav1/uav_manager/errors",
+  };
+
+  const std::vector<std::string> expected_source_nodes_ = {
+      "EstimationManager",
+      "ControlManager",
+      "UavManager",
+  };
+
+  const std::set<std::string> known_dependencies_ = {
+      "HwApiManager",
+      "ControlManager",
+      "EstimationManager",
+  };
+
+  void errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg);
+};
+
+Tester::Tester() : mrs_uav_testing::TestGeneric() {
+
+  topics_.resize(topic_names_.size());
+
+  for (size_t i = 0; i < topic_names_.size(); i++) {
+    topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
+        topic_names_[i], 100,
+        [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+  }
+}
+
+void Tester::errorsCallback(size_t idx, const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) {
+  std::scoped_lock lck(mtx_);
+  topics_[idx].last_msg = *msg;
+}
+
+bool Tester::test(void) {
+
+  RCLCPP_INFO(node_->get_logger(), "Waiting for at least one manager to report waiting_for_node errors...");
+
+  const double timeout_s = 30.0;
+  const double poll_rate_s = 0.2;
+
+  double elapsed = 0.0;
+
+  while (rclcpp::ok() && elapsed < timeout_s) {
+
+    sleep(poll_rate_s);
+    elapsed += poll_rate_s;
+
+    std::scoped_lock lck(mtx_);
+
+    for (size_t i = 0; i < topics_.size(); i++) {
+
+      if (!topics_[i].last_msg.has_value()) {
+        continue;
+      }
+
+      const auto& element = topics_[i].last_msg.value();
+
+      // Verify the source_node matches what we expect
+      if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
+        continue;
+      }
+
+      for (const auto& error : element.errors) {
+        if (error.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_NODE) {
+
+          // Verify waited_for_node is a known dependency
+          if (known_dependencies_.count(error.waited_for_node.node) > 0) {
+            topics_[i].saw_waiting_error = true;
+            RCLCPP_INFO(node_->get_logger(), "%s is waiting for node: %s",
+                         expected_source_nodes_[i].c_str(), error.waited_for_node.node.c_str());
+          }
+        }
+      }
+    }
+
+    // Check if at least one manager reported waiting errors
+    for (const auto& t : topics_) {
+      if (t.saw_waiting_error) {
+        RCLCPP_INFO(node_->get_logger(), "SUCCESS: at least one manager reported waiting_for_node errors during startup.");
+        return true;
+      }
+    }
+  }
+
+  RCLCPP_ERROR(node_->get_logger(),
+               "FAILED: no manager reported waiting_for_node errors within %.1f seconds.", timeout_s);
+  return false;
+}
+
+int main(int argc, char* argv[]) {
+
+  rclcpp::init(argc, argv);
+
+  bool test_result = true;
+
+  Tester tester;
+
+  test_result &= tester.test();
+
+  tester.sleep(2.0);
+
+  std::cout << "Test: reporting test results" << std::endl;
+
+  tester.reportTestResult(test_result);
+
+  tester.join();
+}

--- a/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
+++ b/test/errorgraph/errorgraph_managers_report_waiting/test.cpp
@@ -21,13 +21,14 @@ public:
   bool test(void);
 
 private:
-  struct TopicState {
+  struct TopicState
+  {
     rclcpp::Subscription<mrs_msgs::msg::ErrorgraphElement>::SharedPtr sub;
-    std::optional<mrs_msgs::msg::ErrorgraphElement> last_msg;
-    bool saw_waiting_error = false;
+    std::optional<mrs_msgs::msg::ErrorgraphElement>                   last_msg;
+    bool                                                              saw_waiting_error = false;
   };
 
-  std::mutex mtx_;
+  std::mutex              mtx_;
   std::vector<TopicState> topics_;
 
   // Expected source_node names and their known dependencies
@@ -58,8 +59,7 @@ Tester::Tester() : mrs_uav_testing::TestGeneric() {
 
   for (size_t i = 0; i < topic_names_.size(); i++) {
     topics_[i].sub = node_->create_subscription<mrs_msgs::msg::ErrorgraphElement>(
-        topic_names_[i], 100,
-        [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
+        topic_names_[i], 100, [this, i](const mrs_msgs::msg::ErrorgraphElement::SharedPtr msg) { errorsCallback(i, msg); });
   }
 }
 
@@ -72,7 +72,7 @@ bool Tester::test(void) {
 
   RCLCPP_INFO(node_->get_logger(), "Waiting for at least one manager to report waiting_for_node errors...");
 
-  const double timeout_s = 30.0;
+  const double timeout_s   = 30.0;
   const double poll_rate_s = 0.2;
 
   double elapsed = 0.0;
@@ -90,28 +90,27 @@ bool Tester::test(void) {
         continue;
       }
 
-      const auto& element = topics_[i].last_msg.value();
+      const auto &element = topics_[i].last_msg.value();
 
       // Verify the source_node matches what we expect
       if (element.source_node.node != expected_source_nodes_[i] || element.source_node.component != "main") {
         continue;
       }
 
-      for (const auto& error : element.errors) {
+      for (const auto &error : element.errors) {
         if (error.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_NODE) {
 
           // Verify waited_for_node is a known dependency
           if (known_dependencies_.count(error.waited_for_node.node) > 0) {
             topics_[i].saw_waiting_error = true;
-            RCLCPP_INFO(node_->get_logger(), "%s is waiting for node: %s",
-                         expected_source_nodes_[i].c_str(), error.waited_for_node.node.c_str());
+            RCLCPP_INFO(node_->get_logger(), "%s is waiting for node: %s", expected_source_nodes_[i].c_str(), error.waited_for_node.node.c_str());
           }
         }
       }
     }
 
     // Check if at least one manager reported waiting errors
-    for (const auto& t : topics_) {
+    for (const auto &t : topics_) {
       if (t.saw_waiting_error) {
         RCLCPP_INFO(node_->get_logger(), "SUCCESS: at least one manager reported waiting_for_node errors during startup.");
         return true;
@@ -119,12 +118,11 @@ bool Tester::test(void) {
     }
   }
 
-  RCLCPP_ERROR(node_->get_logger(),
-               "FAILED: no manager reported waiting_for_node errors within %.1f seconds.", timeout_s);
+  RCLCPP_ERROR(node_->get_logger(), "FAILED: no manager reported waiting_for_node errors within %.1f seconds.", timeout_s);
   return false;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
   rclcpp::init(argc, argv);
 

--- a/test/errorgraph/errorgraph_managers_report_waiting/test.py
+++ b/test/errorgraph/errorgraph_managers_report_waiting/test.py
@@ -18,9 +18,10 @@ from std_msgs.msg import Bool
 
 def generate_test_description():
 
-    SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp')
 
     ld = launch.LaunchDescription()
+
+    ld.add_action(SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'))
 
     uav_type="x500"
     uav_name="uav1"

--- a/test/errorgraph/errorgraph_managers_report_waiting/test.py
+++ b/test/errorgraph/errorgraph_managers_report_waiting/test.py
@@ -1,0 +1,152 @@
+import time
+import unittest
+import os
+import sys
+
+import launch
+import launch_ros
+import launch_testing.actions
+import launch_testing.asserts
+from launch.actions import IncludeLaunchDescription, GroupAction, SetEnvironmentVariable
+import rclpy
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
+
+from std_msgs.msg import Bool
+
+def generate_test_description():
+
+    SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp')
+
+    ld = launch.LaunchDescription()
+
+    uav_type="x500"
+    uav_name="uav1"
+    platform_config=get_package_share_directory("mrs_multirotor_simulator")+"/config/mrs_uav_system/"+uav_type+".yaml"
+
+    launch_file_path = os.path.abspath(__file__)
+    launch_dir = os.path.dirname(launch_file_path)
+
+    test_name = os.path.basename(launch_dir)
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                        'launch',
+                        'mrs_uav_system.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'run_automatic_start': "true",
+                        'uav_name': uav_name,
+                        'platform_config': platform_config,
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                            'launch',
+                            'mrs_multirotor_simulator.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'custom_config': launch_dir+"/config/mrs_simulator.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_multirotor_simulator'),
+                            'launch',
+                            'hw_api.launch.py'
+                        ])
+                    ]),
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+            launch_ros.actions.Node(
+                package='mrs_uav_managers',
+                namespace='',
+                executable='test_'+test_name,
+                name='test_'+test_name,
+                output="screen",
+                parameters=[
+                        {'test_name': test_name},
+                ],
+            )
+        )
+
+    ld.add_action(
+        launch.actions.TimerAction(
+            period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        )
+
+    return ld
+
+class PublisherHandlerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('integration_test_handler')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_interactor(self, proc_output, timeout=120):
+
+        """Check whether pose messages published"""
+
+        test_result = []
+
+        sub = self.node.create_subscription(
+                Bool, '/test_result',
+                lambda msg: test_result.append(msg), 100)
+        try:
+
+            end_time = time.time() + timeout
+
+            while time.time() < end_time:
+
+                if len(test_result) > 0:
+                    break
+
+                rclpy.spin_once(self.node, timeout_sec=1)
+
+            time.sleep(2.0)
+
+            # check if we have the result
+            self.assertTrue(len(test_result) > 0)
+
+            # check if the result is true
+            self.assertTrue(test_result[0].data)
+
+        finally:
+            self.node.destroy_subscription(sub)


### PR DESCRIPTION
# BREAKING CHANGE, depends on https://github.com/ctu-mrs/mrs_lib/pull/96 ✅ Merged

# Errorgraph integration

- Added **ErrorPublisher** instances to `UAVManager`, `ControlManager`, `EstimationManager`, and **estimator base classes**
- Replaced `rclcpp::shutdown()` and `exit()` calls with `error_publisher_->flushAndShutdown()` for graceful error handling
- Added error reporting calls: `addOneshotError()`, `addWaitingForNodeError()`, `addGeneralError()` at error points throughout the codebase

- Tests for error reporting and cleanup after initialization


## Verification
Locally, tests are passing:  (There is a circular dependency with `mrs_uav_estimators` in the integration tests.

```cpp
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_max_height_check_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_max_throttle_check_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_midair_service_fail_cause_controller_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_midair_service_fail_cause_enabling_offboard_failed_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_midair_service_fail_cause_enabling_output_failed_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_midair_service_fail_cause_tracker_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_min_height_check_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_takeoff_service_fail_cause_controller_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_takeoff_service_fail_cause_tracker_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_takeoff_service_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/test_uav_manager_uav_manager_start_stop_test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
build/mrs_uav_managers/test_results/mrs_uav_managers/xmllint.xunit.xml: 2 tests, 0 errors, 0 failures, 0 skipped

Summary: 191 tests, 0 errors, 0 failures, 0 skipped

```

If you want to verify locally, you can use the [mrs_uav_core](https://github.com/ctu-mrs/mrs_uav_core/tree/ros2_errorgraph) in the `ros2_errorgraph` branch for building your workspace, running tests, etc. 


