### PR TITLE
[ROS2] Fix RViz visualization in SafetyAreaManager

### DIFF
--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -222,7 +222,7 @@ private:
   std::unique_ptr<mrs_lib::safety_zone::Prism> makePrism(const std::vector<mrs_msgs::msg::Point2D> &points, const double max_z, const double min_z,
                                                          const std::string &horizontal_frame, const std::string &vertical_frame);
   // Transform prism
-  std::optional<mrs_lib::safety_zone::Prism> transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame);
+  std::optional<mrs_lib::safety_zone::Prism> transformPrism(const mrs_lib::safety_zone::Prism &prism, const std::string &target_frame);
 
   std::tuple<bool, std::vector<mrs_lib::safety_zone::Point2d>> transformPoints(const std::vector<mrs_lib::safety_zone::Point2d> &points,
                                                                                const std::string &from_frame, const std::string &target_frame);
@@ -1420,7 +1420,7 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
 
 /* transformPrism() //{ */
 
-std::optional<mrs_lib::safety_zone::Prism> SafetyAreaManager::transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame) {
+std::optional<mrs_lib::safety_zone::Prism> SafetyAreaManager::transformPrism(const mrs_lib::safety_zone::Prism &prism, const std::string &target_frame) {
 
   auto border_points                        = prism.getPoints();
   auto [success, transformed_border_points] = transformPoints(border_points, prism.getHorizontalFrame(), target_frame);

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -1429,7 +1429,7 @@ std::optional<mrs_lib::safety_zone::Prism> SafetyAreaManager::transformPrism(mrs
   auto [z_success_min, transformed_min_z] = transformZ(prism.getVerticalFrame(), target_frame, prism.getMinZ());
 
   if (!success || !z_success_max || !z_success_min) {
-    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "Failed to transform safety border points to %s frame. Will retry later.", target_frame.c_str());
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "Failed to transform safety zone points to %s frame. Will retry later.", target_frame.c_str());
     return std::nullopt;
   }
 

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -94,9 +94,11 @@ private:
   struct VisualizationComponents
   {
     std::vector<std::unique_ptr<mrs_lib::StaticEdgesVisualization>> static_edges;
+    bool                                                            initialized = false;
 
     void safeCleanup() {
       static_edges.clear();
+      initialized = false;
     }
   };
 
@@ -220,7 +222,7 @@ private:
   std::unique_ptr<mrs_lib::safety_zone::Prism> makePrism(const std::vector<mrs_msgs::msg::Point2D> &points, const double max_z, const double min_z,
                                                          const std::string &horizontal_frame, const std::string &vertical_frame);
   // Transform prism
-  mrs_lib::safety_zone::Prism transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame);
+  std::optional<mrs_lib::safety_zone::Prism> transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame);
 
   std::tuple<bool, std::vector<mrs_lib::safety_zone::Point2d>> transformPoints(const std::vector<mrs_lib::safety_zone::Point2d> &points,
                                                                                const std::string &from_frame, const std::string &target_frame);
@@ -546,6 +548,44 @@ void SafetyAreaManager::timerStatus() {
   if (!got_odom) {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 5000, "waiting for data: Odometry=%s", got_odom ? "true" : "FALSE");
     return;
+  }
+
+  // RViz Visualizations, only once we have the safety zone defined and there is a transform available to the local_origin frame.
+  if (safety_zone_handler_.safety_zone && !safety_zone_handler_.visualization_components.initialized) {
+    std::scoped_lock lock(mutex_safety_area_);
+
+    bool all_transforms_done = true;
+
+    // Transform prism to local_origin frame for visualization
+    auto border_prism      = safety_zone_handler_.safety_zone->getBorder();
+    auto transformed_prism = transformPrism(border_prism, "local_origin");
+
+    if (!transformed_prism) {
+      all_transforms_done = false;
+    } else {
+      safety_zone_handler_.visualization_components.static_edges.push_back(
+          std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism.value(), _uav_name_, "local_origin", node_, 2));
+
+      // Obstacles if safety zone is already defined and transformed successfully
+      const auto &obstacles = safety_zone_handler_.safety_zone->getObstacles();
+      for (const auto &[id, obstacle_ptr] : obstacles) {
+        // Transform obstacle prism to local_origin frame
+        auto transformed_obstacle_prism = transformPrism(*obstacle_ptr, "local_origin");
+
+        if (!transformed_obstacle_prism) {
+          all_transforms_done = false;
+          break;
+        }
+        safety_zone_handler_.visualization_components.static_edges.push_back(
+            std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism.value(), _uav_name_, "local_origin", node_, 2));
+      }
+    }
+
+    if (all_transforms_done) {
+      safety_zone_handler_.visualization_components.initialized = true;
+    } else {
+      safety_zone_handler_.visualization_components.safeCleanup();
+    }
   }
 
   auto current_border = safety_zone_handler_.safety_zone->getBorder();
@@ -1303,23 +1343,6 @@ SafetyAreaManager::createSafetyZone(std::unique_ptr<mrs_lib::safety_zone::Prism>
     return std::nullopt;
   }
 
-  // Transform prism to local_origin frame for visualization
-  auto border_prism      = safety_zone_handler.safety_zone->getBorder();
-  auto transformed_prism = transformPrism(border_prism, "local_origin");
-
-  // RViz Visualizations
-  safety_zone_handler.visualization_components.static_edges.push_back(
-      std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism, _uav_name_, "local_origin", node_, 2));
-
-  /* // Obstacles, overloading for obstacles */
-  const auto &obstacles = safety_zone_handler.safety_zone->getObstacles();
-  for (const auto &[id, obstacle_ptr] : obstacles) {
-    // Transform obstacle prism to local_origin frame
-    auto transformed_obstacle_prism = transformPrism(*obstacle_ptr, "local_origin");
-    safety_zone_handler.visualization_components.static_edges.push_back(
-        std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism, _uav_name_, "local_origin", node_, 2));
-  }
-
   // Copy parameters from previous safety zone if exists
   if (safety_zone_handler_.safety_zone) {
     safety_zone_handler.parameters = safety_zone_handler_.parameters;
@@ -1397,7 +1420,7 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
 
 /* transformPrism() //{ */
 
-mrs_lib::safety_zone::Prism SafetyAreaManager::transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame) {
+std::optional<mrs_lib::safety_zone::Prism> SafetyAreaManager::transformPrism(mrs_lib::safety_zone::Prism &prism, const std::string &target_frame) {
 
   auto border_points                        = prism.getPoints();
   auto [success, transformed_border_points] = transformPoints(border_points, prism.getHorizontalFrame(), target_frame);
@@ -1406,8 +1429,8 @@ mrs_lib::safety_zone::Prism SafetyAreaManager::transformPrism(mrs_lib::safety_zo
   auto [z_success_min, transformed_min_z] = transformZ(prism.getVerticalFrame(), target_frame, prism.getMinZ());
 
   if (!success || !z_success_max || !z_success_min) {
-    RCLCPP_WARN(node_->get_logger(), "Failed to transform safety border points to %s frame.", target_frame.c_str());
-    return prism;
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *clock_, 1000, "Failed to transform safety border points to %s frame. Will retry later.", target_frame.c_str());
+    return std::nullopt;
   }
 
   return mrs_lib::safety_zone::Prism(transformed_border_points, transformed_max_z, transformed_min_z, target_frame, target_frame);

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -551,40 +551,41 @@ void SafetyAreaManager::timerStatus() {
   }
 
   // RViz Visualizations, only once we have the safety zone defined and there is a transform available to the local_origin frame.
-  if (safety_zone_handler_.safety_zone && !safety_zone_handler_.visualization_components.initialized) {
+  {
     std::scoped_lock lock(mutex_safety_area_);
+    if (safety_zone_handler_.safety_zone && !safety_zone_handler_.visualization_components.initialized) {
+      bool all_transforms_done = true;
 
-    bool all_transforms_done = true;
+      // Transform prism to local_origin frame for visualization
+      auto border_prism      = safety_zone_handler_.safety_zone->getBorder();
+      auto transformed_prism = transformPrism(border_prism, "local_origin");
 
-    // Transform prism to local_origin frame for visualization
-    auto border_prism      = safety_zone_handler_.safety_zone->getBorder();
-    auto transformed_prism = transformPrism(border_prism, "local_origin");
-
-    if (!transformed_prism) {
-      all_transforms_done = false;
-    } else {
-      safety_zone_handler_.visualization_components.static_edges.push_back(
-          std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism.value(), _uav_name_, "local_origin", node_, 2));
-
-      // Obstacles if safety zone is already defined and transformed successfully
-      const auto &obstacles = safety_zone_handler_.safety_zone->getObstacles();
-      for (const auto &[id, obstacle_ptr] : obstacles) {
-        // Transform obstacle prism to local_origin frame
-        auto transformed_obstacle_prism = transformPrism(*obstacle_ptr, "local_origin");
-
-        if (!transformed_obstacle_prism) {
-          all_transforms_done = false;
-          break;
-        }
+      if (!transformed_prism) {
+        all_transforms_done = false;
+      } else {
         safety_zone_handler_.visualization_components.static_edges.push_back(
-            std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism.value(), _uav_name_, "local_origin", node_, 2));
-      }
-    }
+            std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism.value(), _uav_name_, "local_origin", node_, 2));
 
-    if (all_transforms_done) {
-      safety_zone_handler_.visualization_components.initialized = true;
-    } else {
-      safety_zone_handler_.visualization_components.safeCleanup();
+        // Obstacles if safety zone is already defined and transformed successfully
+        const auto &obstacles = safety_zone_handler_.safety_zone->getObstacles();
+        for (const auto &[id, obstacle_ptr] : obstacles) {
+          // Transform obstacle prism to local_origin frame
+          auto transformed_obstacle_prism = transformPrism(*obstacle_ptr, "local_origin");
+
+          if (!transformed_obstacle_prism) {
+            all_transforms_done = false;
+            break;
+          }
+          safety_zone_handler_.visualization_components.static_edges.push_back(
+              std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism.value(), _uav_name_, "local_origin", node_, 2));
+        }
+      }
+
+      if (all_transforms_done) {
+        safety_zone_handler_.visualization_components.initialized = true;
+      } else {
+        safety_zone_handler_.visualization_components.safeCleanup();
+      }
     }
   }
 


### PR DESCRIPTION
* Added an `initialized` flag to the `VisualizationComponents` struct and updated its `safeCleanup()` method to reset this flag, ensuring proper tracking and cleanup of visualization state.
* Removed visualization initialization from `createSafetyZone()` and consolidated it into the periodic timer logic, ensuring the RViz visualization creation. Refactored the visualization initialization logic in `timerStatus()` to only create visualizations when all transforms to the `local_origin` frame succeed; otherwise, it cleans up any partial visualizations and retries later.

* Changed the `transformPrism` method to return a `std::optional<Prism>`, allowing for explicit handling of transformation failures. Improved error handling in `transformPrism` by using throttled logging and returning `std::nullopt` on failure, enabling retry logic and preventing incorrect visualizations.