### PR TITLE
Throttle model update

### DIFF
--- a/include/mrs_uav_managers/control_manager/common_handlers.h
+++ b/include/mrs_uav_managers/control_manager/common_handlers.h
@@ -66,16 +66,16 @@ struct ControlOutputModalities_t
 
 struct CommonHandlers_t
 {
-  SafetyArea_t                                     safety_area;
-  std::shared_ptr<mrs_lib::Transformer>            transformer;
-  ScopeTimer_t                                     scope_timer;
-  getMass_t                                        getMass;
-  double                                           g;
-  mrs_lib::quadratic_throttle_model::MotorParams_t throttle_model;
-  std::optional<DetailedModelParams_t>             detailed_model_params;
-  ControlOutputModalities_t                        control_output_modalities;
-  std::string                                      uav_name;
-  ros::NodeHandle                                  parent_nh;
+  SafetyArea_t                                      safety_area;
+  std::shared_ptr<mrs_lib::Transformer>             transformer;
+  ScopeTimer_t                                      scope_timer;
+  getMass_t                                         getMass;
+  double                                            g;
+  mrs_lib::quadratic_throttle_model::motor_params_t throttle_model;
+  std::optional<DetailedModelParams_t>              detailed_model_params;
+  ControlOutputModalities_t                         control_output_modalities;
+  std::string                                       uav_name;
+  ros::NodeHandle                                   parent_nh;
 };
 
 }  // namespace control_manager

--- a/src/control_manager/control_manager.cpp
+++ b/src/control_manager/control_manager.cpp
@@ -996,9 +996,10 @@ void ControlManager::initialize(void) {
   param_loader.loadParam("g", common_handlers_->g);
 
   // motor params are also not prefixed, since they are common to more nodes
-  param_loader.loadParam("motor_params/a", common_handlers_->throttle_model.A);
-  param_loader.loadParam("motor_params/b", common_handlers_->throttle_model.B);
-  param_loader.loadParam("motor_params/n_motors", common_handlers_->throttle_model.n_motors);
+  common_handlers_->throttle_model.initialize(param_loader);
+  /* param_loader.loadParam("motor_params/a", common_handlers_->throttle_model.A); */
+  /* param_loader.loadParam("motor_params/b", common_handlers_->throttle_model.B); */
+  /* param_loader.loadParam("motor_params/n_motors", common_handlers_->throttle_model.n_motors); */
 
   // | ----------------------- safety area ---------------------- |
 

--- a/src/uav_manager.cpp
+++ b/src/uav_manager.cpp
@@ -267,7 +267,7 @@ public:
   // diagnostics timer
   double _diagnostics_timer_rate_;
 
-  mrs_lib::quadratic_throttle_model::MotorParams_t _throttle_model_;
+  mrs_lib::quadratic_throttle_model::motor_params_t _throttle_model_;
 
   // landing state machine states
   LandingStates_t current_state_landing_  = IDLE_STATE;
@@ -387,9 +387,10 @@ void UavManager::initialize() {
   param_loader.loadParam("g", _g_);
 
   // motor params are also not prefixed, since they are common to more nodes
-  param_loader.loadParam("motor_params/n_motors", _throttle_model_.n_motors);
-  param_loader.loadParam("motor_params/a", _throttle_model_.A);
-  param_loader.loadParam("motor_params/b", _throttle_model_.B);
+  _throttle_model_.initialize(param_loader);
+  /* param_loader.loadParam("motor_params/n_motors", _throttle_model_.n_motors); */
+  /* param_loader.loadParam("motor_params/a", _throttle_model_.A); */
+  /* param_loader.loadParam("motor_params/b", _throttle_model_.B); */
 
   param_loader.loadParam(yaml_prefix + "null_tracker", _null_tracker_name_);
 


### PR DESCRIPTION
Integration of the full quadratic throttle model (i.e. including the linear term) from [mrs_lib/PR#97](https://github.com/ctu-mrs/mrs_lib/pull/97).

The implementation is backwards-compatible with the original model. Tested in simulations and in real-world flights with Eagle.