### PR TITLE
Fix/estimators errorgraph reporting

### DIFF
--- a/include/mrs_uav_managers/estimation_manager/estimator.h
+++ b/include/mrs_uav_managers/estimation_manager/estimator.h
@@ -76,11 +76,11 @@ public:
   virtual bool start(void)                                                                                                                                = 0;
   virtual bool pause(void)                                                                                                                                = 0;
   virtual bool reset(void)                                                                                                                                = 0;
+  virtual std::string getPrintName(void) const;
 
   // implemented methods
   // access methods
   std::string getName(void) const;
-  std::string getPrintName(void) const;
   std::string getType(void) const;
   std::string getFrameId(void) const;
   double      getMaxFlightZ(void) const;

--- a/src/estimation_manager/estimation_manager.cpp
+++ b/src/estimation_manager/estimation_manager.cpp
@@ -971,7 +971,7 @@ void EstimationManager::timerPublish() {
     uav_state = ret.value();
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "Active estimator did not provide uav_state.");
-    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getName()});
+    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getPrintName()});
     return;
   }
 
@@ -1048,7 +1048,7 @@ void EstimationManager::timerPublishDiagnostics() {
     uav_state = ret.value();
   } else {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "Active estimator did not provide uav_state.");
-    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getName()});
+    error_publisher_->addWaitingForNodeError({"EstimationManager", active_estimator_->getPrintName()});
     return;
   }
 
@@ -1192,7 +1192,7 @@ void EstimationManager::timerCheckHealth() {
       } else {
         RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "%s agl estimator: %s to be running", Support::waiting_for_string.c_str(),
                              est_alt_agl_->getName().c_str());
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_agl_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_agl_->getPrintName()});
       }
     }
   }


### PR DESCRIPTION
## Summary

  **What changed**
  - Updated `state_generic.cpp` to use `getPrintName()` instead of `getName()` when
    registering `addWaitingForNodeError(...)` for sub-estimators, to specify the component reporting the error.
    e.g: `EstimationManager:gps_garmin/hdg_hw_api`, instead of just `EstimationManager:hdg_hw_api`
  - Made `Estimator::getPrintName()` **virtual** in the base class so derived child classes can override
    (`HdgPassthrough`, `HdgGeneric`, etc.)

  **Why**

  While inspecting `/uav1/errors`, the diagnostics module responsible for gathering the errors was consistently reporting:

      errors:
      - 'EstimationManager.hdg_hw_api: not responding'

 Even though the heading estimator was running. In the errors topic, it showed it is reporting fine, just under a different ID:

      source_node:
        node: EstimationManager
        component: gps_baro/hdg_hw_api
      errors: []

  So the errorgraph component was registering the expected error for `{EstimationManager, hdg_hw_api}.`
  that no publisher is matching, as the estimators are publishing as   `{EstimationManager, gps_baro/hdg_hw_api}`. Reason why we had a stale error "not_reporting" for the estimators.

  **Root cause**
  
  1. `state_generic.cpp` was registering the error with `est_hdg_->getName()`, which
     returns the unqualified estimator name (`hdg_hw_api`) rather than the qualified
     one (`gps_baro/hdg_hw_api`)

  2. Switching the call to `getPrintName()` looked correct but didn't change
     runtime behavior, because `Estimator::getPrintName()` was **not virtual**, with the base class `Estimator::getPrintName` returns just [name_](https://github.com/ctu-mrs/mrs_uav_managers/blob/ros2/src/estimation_manager/estimator.cpp#L138)

       Specifically in the heading estimators, the methods are [defined](https://github.com/ctu-mrs/mrs_uav_state_estimators/blob/ros2/src/estimators/heading/hdg_generic.cpp#L667), but silently shadowed. 
       

  
## Impact
- **Affected areas**: Errorgraph reporting, will open PR on `mrs_uav_estimators` to override this method to have the expected behavior: https://github.com/ctu-mrs/mrs_uav_state_estimators/pull/14
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW