### PR TITLE
fix: try catch on unvalid prism creation

### DIFF
--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -33,6 +33,7 @@
 #include <limits>
 #include <memory>
 #include <cmath>
+#include <exception>
 
 #include <mrs_msgs/msg/point2_d.hpp>
 #include <mrs_msgs/msg/safety_area_manager_diagnostics.hpp>

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -1395,6 +1395,7 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
 
   if (matrix.rows() < 3) {
     RCLCPP_WARN(node_->get_logger(), "Invalid polygon, must have at least 3 points. Provided:  %zu", matrix.rows());
+    return nullptr;
   }
 
   std::vector<mrs_lib::safety_zone::Point2d> points;
@@ -1404,7 +1405,14 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
     points.emplace_back(mrs_lib::safety_zone::Point2d{matrix(i, 0), matrix(i, 1)});
   }
 
-  auto prism = std::make_unique<mrs_lib::safety_zone::Prism>(points, max_z, min_z, horizontal_frame, vertical_frame);
+  std::unique_ptr<mrs_lib::safety_zone::Prism> prism;
+  try {
+    prism = std::make_unique<mrs_lib::safety_zone::Prism>(points, max_z, min_z, horizontal_frame, vertical_frame);
+  }
+  catch (const std::exception &e) {
+    RCLCPP_WARN(node_->get_logger(), "Failed to create prism from message: %s", e.what());
+    return nullptr;
+  }
 
   return prism;
 }
@@ -1419,6 +1427,7 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
 
   if (points.size() < 3) {
     RCLCPP_WARN(node_->get_logger(), "Invalid polygon, must have at least 3 points. Provided:  %zu", points.size());
+    return nullptr;
   }
 
   std::vector<mrs_lib::safety_zone::Point2d> tmp_points;
@@ -1429,7 +1438,14 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
     tmp_points.emplace_back(mrs_lib::safety_zone::Point2d{point.x, point.y});
   }
 
-  auto prism = std::make_unique<mrs_lib::safety_zone::Prism>(tmp_points, max_z, min_z, horizontal_frame, vertical_frame);
+  std::unique_ptr<mrs_lib::safety_zone::Prism> prism;
+  try {
+    prism = std::make_unique<mrs_lib::safety_zone::Prism>(tmp_points, max_z, min_z, horizontal_frame, vertical_frame);
+  }
+  catch (const std::exception &e) {
+    RCLCPP_WARN(node_->get_logger(), "Failed to create prism from message: %s", e.what());
+    return nullptr;
+  }
 
   return prism;
 }


### PR DESCRIPTION
Adding better error handling and input validation. The main changes ensure that invalid input is handled gracefully and that exceptions during prism creation are caught and logged, preventing potential crashes.

## Summary
- **What changed**:
     - Added try catch upon creation of Prism object.
- **Why**:
    -  Prism is [throwing exception](https://github.com/ctu-mrs/mrs_lib/blob/ros2/src/safety_zone/prism.cpp#L39), which was uncaught and is making the core crash when setting up an invalid safety area.

## Impact
- **Affected areas**: Safety area manager
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [] Tested on real HW
