### PR TITLE
feat: require rtk_antenna tf only when rtk is used

### DIFF
--- a/config/private/estimation_manager/estimation_manager.yaml
+++ b/config/private/estimation_manager/estimation_manager.yaml
@@ -9,7 +9,7 @@ mrs_uav_managers:
     frame_id:
       fcu: "fcu" # the body frame of the UAV where the flight control unit resides (default: "fcu")
       fcu_untilted: "fcu_untilted" # the body frame with zero tilt angles default: ("fcu_untilted")
-      rtk_antenna: "rtk_antenna" # the body frame with zero tilt angles default: ("fcu_untilted")
+      rtk_antenna: "rtk_antenna" # the rtk antenna frame ("rtk_antenna")
 
     rate:
       diagnostics: 10 # [Hz]

--- a/launch/transform_manager.launch.py
+++ b/launch/transform_manager.launch.py
@@ -228,15 +228,4 @@ def generate_launch_description():
 
     # #} end of own container
 
-    ld.add_action(
-        # Nodes under test
-        launch_ros.actions.Node(
-            package='tf2_ros',
-            namespace='',
-            executable='static_transform_publisher',
-            name='fcu_to_rtk_antenna',
-            arguments=["0.0", "0.0", "0.20", "0", "0", "0", [uav_name, "/fcu"], [uav_name, "/rtk_antenna"]],
-        )
-    )
-
     return ld

--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -153,6 +153,8 @@ private:
 
   std::optional<geometry_msgs::msg::Pose> transformRtkToFcu(const geometry_msgs::msg::PoseStamped &pose_in) const;
 
+  bool isRtkUsed() const;
+
   void publishFcuUntiltedTf(const geometry_msgs::msg::QuaternionStamped::ConstSharedPtr msg);
 
   void publishLocalTf();
@@ -474,7 +476,7 @@ void TransformManager::initialize() {
   sh_hw_api_orientation_ =
       mrs_lib::SubscriberHandler<geometry_msgs::msg::QuaternionStamped>(shopts, "~/orientation_in", &TransformManager::callbackHwApiOrientation, this);
 
-  if (utm_source_name_ == "rtk" || utm_source_name_ == "rtk_garmin") {
+  if (isRtkUsed()) {
     sh_rtk_gps_ = mrs_lib::SubscriberHandler<mrs_msgs::msg::RtkGps>(shopts, "~/rtk_gps_in", &TransformManager::callbackRtkGps, this);
   } else {
     sh_gnss_ = mrs_lib::SubscriberHandler<sensor_msgs::msg::NavSatFix>(shopts, "~/gnss_in", &TransformManager::callbackGnss, this);
@@ -493,24 +495,28 @@ void TransformManager::initialize() {
     error_publisher_->flushAndShutdown();
   }
 
-  // Check if the RTK antenna static tf is defined
-  bool got_rtk_antenna_tf = false;
-  for (int i = 0; i < 10; i++) {
-    auto res_tf_rtk = ch_->transformer->getTransform(ch_->frames.ns_rtk_antenna, ch_->frames.ns_fcu, clock_->now());
-    if (res_tf_rtk) {
-      RCLCPP_INFO(node_->get_logger(), "[%s] got tf from FCU to RTK antenna", getPrintName().c_str());
-      got_rtk_antenna_tf = true;
-      break;
-    }
-    RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] %s tf from FCU to RTK antenna", getPrintName().c_str(), Support::waiting_for_string.c_str());
-    clock_->sleep_for(0.5s);
-  }
 
-  if (!got_rtk_antenna_tf) {
-    RCLCPP_ERROR(node_->get_logger(), "[%s]: The transform from FCU to RTK antenna is not defined. Please provide static tf from %s to %s.",
-                 getPrintName().c_str(), ch_->frames.ns_fcu.c_str(), ch_->frames.ns_rtk_antenna.c_str());
-    error_publisher_->addOneshotError("RTK antenna TF not available.");
-    error_publisher_->flushAndShutdown();
+  if (isRtkUsed()) {
+    // Check if the RTK antenna static tf is defined
+    bool got_rtk_antenna_tf = false;
+    for (int i = 0; i < 10; i++) {
+      auto res_tf_rtk = ch_->transformer->getTransform(ch_->frames.ns_rtk_antenna, ch_->frames.ns_fcu, clock_->now());
+      if (res_tf_rtk) {
+        RCLCPP_INFO(node_->get_logger(), "[%s] got tf from FCU to RTK antenna", getPrintName().c_str());
+        got_rtk_antenna_tf = true;
+        break;
+      }
+      RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] %s tf from FCU to RTK antenna", getPrintName().c_str(),
+                           Support::waiting_for_string.c_str());
+      clock_->sleep_for(0.5s);
+    }
+
+    if (!got_rtk_antenna_tf) {
+      RCLCPP_ERROR(node_->get_logger(), "[%s]: The transform from FCU to RTK antenna is not defined. Please provide static tf from %s to %s.",
+                   getPrintName().c_str(), ch_->frames.ns_fcu.c_str(), ch_->frames.ns_rtk_antenna.c_str());
+      error_publisher_->addOneshotError("RTK antenna TF not available.");
+      error_publisher_->flushAndShutdown();
+    }
   }
 
   is_initialized_ = true;
@@ -964,6 +970,12 @@ bool TransformManager::callbackSetWorldOrigin(const std::shared_ptr<mrs_msgs::sr
   return true;
 }
 /*//}*/
+
+/* isRtkUsed() //{ */
+bool TransformManager::isRtkUsed() const {
+  return utm_source_name_ == "rtk" || utm_source_name_ == "rtk_garmin";
+}
+//}
 
 /*//{ publishFcuUntiltedTf() */
 void TransformManager::publishFcuUntiltedTf(const geometry_msgs::msg::QuaternionStamped::ConstSharedPtr msg) {

--- a/test/build_tests.sh
+++ b/test/build_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+while [ ! -e "build/COLCON_IGNORE" ]; do
+  cd ..
+  if [[ `pwd` == "/" ]]; then
+    # we reached the root and didn't find the build/COLCON_IGNORE file - that's a fail!
+    echo "Cannot compile, probably not in a workspace (if you want to create a new workspace, call \"colcon init\" in its root first)".
+    exit 1
+  fi
+done
+
+colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=1

--- a/test/run_specific_test.sh
+++ b/test/run_specific_test.sh
@@ -13,6 +13,7 @@ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 
 colcon test-result --delete-yes
 
-colcon test --packages-select mrs_uav_managers --ctest-args -R 'bumper_with_rc_control' -p 1 --event-handlers console_direct+ console_stderr- console_start_end-
+# colcon test --packages-select mrs_uav_managers --ctest-args -R 'bumper_with_rc_control' -p 1 --event-handlers console_direct+ console_stderr- console_start_end-
+colcon test --packages-select mrs_uav_managers --ctest-args -R 'errorgraph_managers_clear_after_startup' --event-handlers console_direct+ console_stderr- console_start_end-
 
 colcon test-result --all --verbose


### PR DESCRIPTION
## Summary
- **What changed**:
Remove rtk_antenna tf, which was published even when RTK was not used.
- **Why**:
See issue here https://github.com/ctu-mrs/mrs_uav_managers/issues/36
- **Notes for reviewers**:
The check was originally added here https://github.com/ctu-mrs/mrs_uav_managers/commit/59ce663f5fe3b9d6172ea26cfa9233f6c873e48d. So the check should be related only when the RTK callback is used.

## Impact
- **Affected areas**: 
When you enable RTK, you need to add tf manually. Without it, the code will produce an error. This changes the default behavior.  
- **Breaking changes**: 
Yes, for users using RTK. It will force them to create their own tf which should correlate with their hw configuration.  So thanks to that they can potentially achieve better precision with RTK

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [] Tests updated if needed
    * [x] Tested in simulation
    * [] Tested on real HW

- **How to repeat tests**:
 ```bash
Run mrs_multirotor_simulation or mrs_uav_gazebo_simulator tmux sessions.