### PR TITLE
feat: set publishing for mass_nomial topic to be latched

### DIFF
--- a/src/control_manager/control_manager.cpp
+++ b/src/control_manager/control_manager.cpp
@@ -1834,13 +1834,15 @@ void ControlManager::initialize(void) {
   ph_diagnostics_            = mrs_lib::PublisherHandler<mrs_msgs::msg::ControlManagerDiagnostics>(node_, "~/diagnostics_out");
   ph_offboard_on_            = mrs_lib::PublisherHandler<std_msgs::msg::Empty>(node_, "~/offboard_on_out");
   ph_tilt_error_             = mrs_lib::PublisherHandler<mrs_msgs::msg::Float64Stamped>(node_, "~/tilt_error_out");
+
   {
     mrs_lib::PublisherHandlerOptions opts;
-    opts.node = node_;
-    opts.qos  = rclcpp::QoS(1).transient_local();
+    opts.node        = node_;
+    opts.qos         = rclcpp::QoS(1).transient_local();
     ph_mass_nominal_ = mrs_lib::PublisherHandler<std_msgs::msg::Float64>(opts, "~/mass_nominal_out");
   }
-  ph_control_error_          = mrs_lib::PublisherHandler<mrs_msgs::msg::ControlError>(node_, "~/control_error_out");
+
+  ph_control_error_ = mrs_lib::PublisherHandler<mrs_msgs::msg::ControlError>(node_, "~/control_error_out");
 
   {
     mrs_lib::PublisherHandlerOptions opts;

--- a/src/control_manager/control_manager.cpp
+++ b/src/control_manager/control_manager.cpp
@@ -1834,7 +1834,12 @@ void ControlManager::initialize(void) {
   ph_diagnostics_            = mrs_lib::PublisherHandler<mrs_msgs::msg::ControlManagerDiagnostics>(node_, "~/diagnostics_out");
   ph_offboard_on_            = mrs_lib::PublisherHandler<std_msgs::msg::Empty>(node_, "~/offboard_on_out");
   ph_tilt_error_             = mrs_lib::PublisherHandler<mrs_msgs::msg::Float64Stamped>(node_, "~/tilt_error_out");
-  ph_mass_nominal_           = mrs_lib::PublisherHandler<std_msgs::msg::Float64>(node_, "~/mass_nominal_out"); // TODO latch
+  {
+    mrs_lib::PublisherHandlerOptions opts;
+    opts.node = node_;
+    opts.qos  = rclcpp::QoS(1).transient_local();
+    ph_mass_nominal_ = mrs_lib::PublisherHandler<std_msgs::msg::Float64>(opts, "~/mass_nominal_out");
+  }
   ph_control_error_          = mrs_lib::PublisherHandler<mrs_msgs::msg::ControlError>(node_, "~/control_error_out");
 
   {


### PR DESCRIPTION
 ## Summary
   - **What changed**: 
   `ph_mass_nominal_` publisher in `ControlManager` is now created with `transient_local` QoS (ROS 2 equivalent of a latched topic).
   - **Why**: 
   Resolves the `// TODO latch` comment at the publisher declaration. Late-joining subscribers (e.g. tools that inspect the nominal mass after startup) previously received nothing until the next publish cycle.
   - **Notes for reviewers**: 
   Uses `PublisherHandlerOptions` with `rclcpp::QoS(1).transient_local()`. Subscriber-side QoS must be compatible (`TRANSIENT_LOCAL` or `VOLATILE` — VOLATILE subscribers simply won't receive the retained message, which is standard ROS 2 behaviour). New mrs_robot_diagnostics package will be updated to be compatible. Current mrs_uav_status is not compatible, but the new version is coming.

   ## Impact
   - **Affected areas**: `ControlManager` — `mass_nominal_out` topic
   - **Breaking changes**: No

   ## Testing status
   - **What was tested**:
       * [x] Build/test passes
       * [ ] Tests updated if needed
       * [x] Tested in simulation
       * [ ] Tested on real HW

   - **How to repeat tests**:
  run the system with new mrs_uav_status.