### PR TITLE
feat: require garmin tf when garmin is used as an estimator source

### DIFF
--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -27,6 +27,7 @@
 
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -154,6 +155,7 @@ private:
   std::optional<geometry_msgs::msg::Pose> transformRtkToFcu(const geometry_msgs::msg::PoseStamped &pose_in) const;
 
   bool isRtkUsed() const;
+  bool isGarminUsed() const;
 
   void publishFcuUntiltedTf(const geometry_msgs::msg::QuaternionStamped::ConstSharedPtr msg);
 
@@ -515,6 +517,29 @@ void TransformManager::initialize() {
       RCLCPP_ERROR(node_->get_logger(), "[%s]: The transform from FCU to RTK antenna is not defined. Please provide static tf from %s to %s.",
                    getPrintName().c_str(), ch_->frames.ns_fcu.c_str(), ch_->frames.ns_rtk_antenna.c_str());
       error_publisher_->addOneshotError("RTK antenna TF not available.");
+      error_publisher_->flushAndShutdown();
+    }
+  }
+
+  if (isGarminUsed()) {
+    // Check if the garmin static tf is defined
+    const std::string ns_garmin     = ch_->uav_name + "/garmin";
+    bool              got_garmin_tf = false;
+    for (int i = 0; i < 10; i++) {
+      auto res_tf_garmin = ch_->transformer->getTransform(ns_garmin, ch_->frames.ns_fcu, clock_->now());
+      if (res_tf_garmin) {
+        RCLCPP_INFO(node_->get_logger(), "[%s] got tf from FCU to GARMIN", getPrintName().c_str());
+        got_garmin_tf = true;
+        break;
+      }
+      RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s] %s tf from FCU to GARMIN", getPrintName().c_str(), Support::waiting_for_string.c_str());
+      clock_->sleep_for(0.5s);
+    }
+
+    if (!got_garmin_tf) {
+      RCLCPP_ERROR(node_->get_logger(), "[%s]: The transform from FCU to GARMIN is not defined. Please provide static tf from %s to %s.",
+                   getPrintName().c_str(), ch_->frames.ns_fcu.c_str(), ns_garmin.c_str());
+      error_publisher_->addOneshotError("Garmin TF not available.");
       error_publisher_->flushAndShutdown();
     }
   }
@@ -974,6 +999,13 @@ bool TransformManager::callbackSetWorldOrigin(const std::shared_ptr<mrs_msgs::sr
 /* isRtkUsed() //{ */
 bool TransformManager::isRtkUsed() const {
   return utm_source_name_ == "rtk" || utm_source_name_ == "rtk_garmin";
+}
+//}
+
+/* isGarminUsed() //{ */
+bool TransformManager::isGarminUsed() const {
+  return std::any_of(estimator_names_.begin(), estimator_names_.end(),
+                     [](const std::string &estimator_name) { return estimator_name.find("garmin") != std::string::npos; });
 }
 //}
 


### PR DESCRIPTION
## Summary
- **What changed**: 
`TransformManager` now checks whether any active estimator uses `garmin`. If so, it waits (up to 10 attempts, 0.5 s apart) at startup for the static `FCU -> GARMIN` transform to become available, mirroring the existing RTK-antenna check. If the transform never appears, it raises a one-shot error and shuts the node down.
- **Why**: 
Previously the garmin static tf was not validated at startup, so a missing/misconfigured `FCU -> GARMIN` transform would only surface later as a silent estimation failure instead of a clear, early error.
- **Notes for reviewers**: 
Follows the same pattern recently added for the RTK antenna tf requirement (see https://github.com/ctu-mrs/mrs_uav_managers/pull/40); the check is skipped entirely when no active estimator uses garmin, so UAVs not using garmin are unaffected.
Related to changes around https://github.com/ctu-mrs/mrs_uav_gazebo_simulator/pull/40

## Impact
- **Affected areas**: `
TransformManager` (`src/transform_manager/transform_manager.cpp`)
- **Breaking changes**: 
No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
run simulation without fcu_to_garmin tf. For example using https://github.com/ctu-mrs/mrs_uav_px4_api/pull/18