### PR TITLE
Fix/world origin runtime change

### DIFF
--- a/include/transform_manager/tf_source.h
+++ b/include/transform_manager/tf_source.h
@@ -201,6 +201,14 @@ public:
   }
   /*//}*/
 
+  /*//{ invalidateFirstMsg() */
+  // forces recapture of the reference odom msg; call after the estimator frame is re-anchored (e.g.
+  // world-origin change + estimator reset), else the stale reference offsets the utm/world tfs
+  void invalidateFirstMsg() {
+    got_first_msg_ = false;
+  }
+  /*//}*/
+
 private:
   const std::string name_;
   const std::string ns_fcu_frame_id_;
@@ -252,7 +260,7 @@ private:
   mrs_lib::SubscriberHandler<nav_msgs::msg::Odometry>               sh_tf_source_odom_;
   mrs_lib::SubscriberHandler<geometry_msgs::msg::QuaternionStamped> sh_tf_source_att_;
   nav_msgs::msg::Odometry::ConstSharedPtr                           first_msg_;
-  bool                                                              got_first_msg_ = false;
+  std::atomic_bool                                                  got_first_msg_ = false;
 
 
   /*//{ callbackTfSourceOdom()*/

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -1365,6 +1365,9 @@ SafetyAreaManager::createSafetyZone(std::unique_ptr<mrs_lib::safety_zone::Prism>
   // Copy parameters from previous safety zone if exists
   if (safety_zone_handler_.safety_zone) {
     safety_zone_handler.parameters = safety_zone_handler_.parameters;
+    // a freshly constructed zone defaults to disabled; carry over the current state so that
+    // rebuilding the zone (world-origin change, new border) does not silently drop the fence
+    safety_zone_handler.safety_zone->enableSafetyZone(safety_zone_handler_.safety_zone->safetyZoneEnabled());
   }
 
   return safety_zone_handler;

--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -132,8 +132,8 @@ private:
   void                                                callbackUavState(const mrs_msgs::msg::UavState::ConstSharedPtr msg);
   std::string                                         first_frame_id_;
   std::string                                         last_frame_id_;
-  bool                                                is_first_frame_id_set_        = false;
-  bool                                                is_local_static_tf_published_ = false;
+  std::atomic_bool                                    is_first_frame_id_set_        = false;
+  std::atomic_bool                                    is_local_static_tf_published_ = false;
 
   mrs_lib::SubscriberHandler<mrs_msgs::msg::Float64Stamped> sh_height_agl_;
   void                                                      callbackHeightAgl(const mrs_msgs::msg::Float64Stamped::ConstSharedPtr msg);
@@ -966,6 +966,11 @@ bool TransformManager::callbackSetWorldOrigin(const std::shared_ptr<mrs_msgs::sr
     // invalidate the stale reference so the utm/world tfs re-capture it in the new frame
     tf_sources_[i]->invalidateFirstMsg();
   }
+
+  // local_origin is anchored to the first uav_state, taken in the previous frame; drop it so the
+  // next uav_state re-anchors it, otherwise the frame stays offset by the world origin change
+  is_first_frame_id_set_        = false;
+  is_local_static_tf_published_ = false;
 
   response->success = true;
   response->message = "World origin set successfully";

--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -962,6 +962,9 @@ bool TransformManager::callbackSetWorldOrigin(const std::shared_ptr<mrs_msgs::sr
 
   for (size_t i = 0; i < tf_sources_.size(); i++) {
     tf_sources_[i]->setWorldOrigin(world_origin);
+    // the estimators are reset when the world origin changes, which re-anchors their odom frame;
+    // invalidate the stale reference so the utm/world tfs re-capture it in the new frame
+    tf_sources_[i]->invalidateFirstMsg();
   }
 
   response->success = true;

--- a/test/estimation_manager/CMakeLists.txt
+++ b/test/estimation_manager/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(set_world_origin_runtime)
 add_subdirectory(switch_estimator_service)

--- a/test/estimation_manager/set_world_origin_runtime/CMakeLists.txt
+++ b/test/estimation_manager/set_world_origin_runtime/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+add_mrs_uav_managers_test_target("${TEST_NAME}")

--- a/test/estimation_manager/set_world_origin_runtime/config/custom_config.yaml
+++ b/test/estimation_manager/set_world_origin_runtime/config/custom_config.yaml
@@ -1,0 +1,28 @@
+# GET ALL PARAMETERS USABLE FOR CUSTOM CONFIG BY RUNNING:
+## --------------------------------------------------------------
+## |          rosrun mrs_uav_core get_public_params.py          #
+## --------------------------------------------------------------
+
+mrs_uav_managers:
+
+  estimation_manager:
+
+    # loaded state estimator plugins
+    state_estimators: [
+      "gps_baro",
+      "gps_garmin",
+      # "rtk",
+      # "rtk_garmin",
+      "passthrough",
+    ]
+
+    initial_state_estimator: "gps_baro" # will be used as the first state estimator
+    agl_height_estimator: "" # only slightly filtered height for checking min height (not used in control feedback)
+
+  uav_manager:
+
+    midair_activation:
+
+      after_activation:
+        controller: "Se3Controller"
+        tracker: "MpcTracker"

--- a/test/estimation_manager/set_world_origin_runtime/config/mrs_simulator.yaml
+++ b/test/estimation_manager/set_world_origin_runtime/config/mrs_simulator.yaml
@@ -1,0 +1,11 @@
+# turning off for the takeoff test
+individual_takeoff_platform:
+  enabled: false
+
+uav1:
+  type: "x500"
+  spawn:
+    x: 10.0
+    y: 20.0
+    z: 0.5
+    heading: 1.2

--- a/test/estimation_manager/set_world_origin_runtime/config/world_config.yaml
+++ b/test/estimation_manager/set_world_origin_runtime/config/world_config.yaml
@@ -1,0 +1,42 @@
+mrs_uav_managers:
+
+  world_origin:
+
+    units: "LATLON" # {"UTM, "LATLON"}
+
+    origin_x: 47.397743
+    origin_y: 8.545594
+
+  safety_area_manager:
+
+    safety_area:
+
+      enabled: true
+
+      horizontal:
+
+        # the frame of reference in which the points are expressed
+        # frame_name: "local_origin"
+        frame_name: "world_origin"
+
+        # polygon
+        #
+        # x, y [m] for any frame_name except latlon_origin
+        # x = latitude, y = longitude [deg]  for frame_name=="latlon_origin"
+        points: [
+          -50, -50,
+          50,  -50,
+          50,  50,
+          -50, 50,
+        ]
+      vertical:
+
+        # the frame of reference in which the max&min z is expressed
+        frame_name: "world_origin"
+
+        max_z: 15.0
+        min_z: 0.5
+
+      obstacles:
+
+        present: false

--- a/test/estimation_manager/set_world_origin_runtime/test.cpp
+++ b/test/estimation_manager/set_world_origin_runtime/test.cpp
@@ -1,0 +1,273 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+
+#include <mrs_lib/service_client_handler.h>
+
+#include <mrs_msgs/srv/get_bool_srv.hpp>
+#include <mrs_msgs/srv/reference_stamped_srv.hpp>
+
+#include <mrs_uav_testing/test_generic.h>
+
+using namespace std::chrono_literals;
+
+class Tester : public mrs_uav_testing::TestGeneric {
+
+public:
+  Tester() : mrs_uav_testing::TestGeneric() {
+  }
+
+  bool test(void);
+
+  std::shared_ptr<mrs_uav_testing::UAVHandler> uh_;
+
+private:
+  std::optional<geometry_msgs::msg::Point> positionInFrame(const std::string &frame);
+};
+
+/* positionInFrame() //{ */
+
+// the current UAV position expressed in the given frame
+std::optional<geometry_msgs::msg::Point> Tester::positionInFrame(const std::string &frame) {
+
+  if (!uh_->sh_uav_state_.hasMsg()) {
+    return std::nullopt;
+  }
+
+  auto uav_state = uh_->sh_uav_state_.getMsg();
+
+  mrs_msgs::msg::ReferenceStamped ref;
+  ref.header.frame_id      = uav_state->header.frame_id;
+  ref.reference.position.x = uav_state->pose.position.x;
+  ref.reference.position.y = uav_state->pose.position.y;
+  ref.reference.position.z = uav_state->pose.position.z;
+
+  auto tfed = uh_->transformer_->transformSingle(ref, frame);
+
+  if (!tfed) {
+    return std::nullopt;
+  }
+
+  return tfed->reference.position;
+}
+
+//}
+
+bool Tester::test(void) {
+
+  const std::string uav_name = "uav1";
+
+  {
+    auto [uhopt, message] = getUAVHandler(uav_name);
+
+    if (!uhopt) {
+      RCLCPP_ERROR(node_->get_logger(), "Failed obtain handler for '%s': '%s'", uav_name.c_str(), message.c_str());
+      return false;
+    }
+
+    uh_ = uhopt.value();
+  }
+
+  auto sch_set_world_origin = mrs_lib::ServiceClientHandler<mrs_msgs::srv::ReferenceStampedSrv>(node_, "/" + uav_name + "/estimation_manager/set_world_origin");
+
+  auto sch_safety_zone_enabled =
+      mrs_lib::ServiceClientHandler<mrs_msgs::srv::GetBoolSrv>(node_, "/" + uav_name + "/safety_area_manager/is_safety_zone_enabled");
+
+  // | ---- wait for the system, the origin can only be set on the ground ---- |
+
+  while (rclcpp::ok() && !uh_->mrsSystemReady()) {
+    RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for the MRS UAV System");
+    this->sleep(0.01);
+  }
+
+  // the fence has to be up front, otherwise checking it after the rebuild proves nothing
+  {
+    auto response = sch_safety_zone_enabled.callSync(std::make_shared<mrs_msgs::srv::GetBoolSrv::Request>());
+
+    if (!response || !response.value()->value) {
+      RCLCPP_ERROR(node_->get_logger(), "the safety zone is not enabled before the world origin change");
+      return false;
+    }
+  }
+
+  // remember the border, the rebuild is detected by it moving with the origin
+  std::vector<mrs_msgs::msg::Point2D> border_before;
+
+  if (uh_->sh_safety_area_manager_diag_.hasMsg()) {
+    border_before = uh_->sh_safety_area_manager_diag_.getMsg()->border.points;
+  }
+
+  if (border_before.empty()) {
+    RCLCPP_ERROR(node_->get_logger(), "no safety area border received before the world origin change");
+    return false;
+  }
+
+  // the UAV stands still for the whole test, so utm_origin - a frame the origin change must not
+  // move - fixes where it is; anything that shifts here is a tf that was left anchored to the
+  // pre-reset estimator frame
+  geometry_msgs::msg::Point utm_before;
+
+  {
+    auto position = positionInFrame(uav_name + "/utm_origin");
+
+    if (!position) {
+      RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in utm_origin before the world origin change");
+      return false;
+    }
+
+    utm_before = position.value();
+  }
+
+  // | ------------- move the world origin at runtime ------------ |
+
+  // this resets the estimators onto the new origin, which re-anchors every frame derived from them,
+  // and it rebuilds the safety area - the two things this test guards
+  {
+    auto request = std::make_shared<mrs_msgs::srv::ReferenceStampedSrv::Request>();
+
+    request->header.frame_id = "latlon_origin";
+    // ~25 m from the configured origin: far enough that a frame left un-anchored is unmistakable
+    // (it lands megametres away), close enough to keep the UAV well inside the safety area
+    request->reference.position.x = 47.397923;
+    request->reference.position.y = 8.545794;
+
+    auto response = sch_set_world_origin.callSync(request);
+
+    if (!response || !response.value()->success) {
+      RCLCPP_ERROR(node_->get_logger(), "set_world_origin failed: '%s'", response ? response.value()->message.c_str() : "no response");
+      return false;
+    }
+  }
+
+  // let the reset estimators produce a few states, so the tfs settle on the new origin
+  this->sleep(3.0);
+
+  // | ------- the origin frames have to keep describing the UAV ------ |
+
+  // the utm/world tfs are derived from the tf source's first odom msg, captured before the reset;
+  // if that reference is not invalidated, they stay offset by however far the origin moved
+  {
+    const double max_drift = 2.0; // [m]
+
+    auto position = positionInFrame(uav_name + "/utm_origin");
+
+    if (!position) {
+      RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in utm_origin after the world origin change");
+      return false;
+    }
+
+    const double drift = std::hypot(position.value().x - utm_before.x, position.value().y - utm_before.y);
+
+    RCLCPP_INFO(node_->get_logger(), "the UAV moved by %.2f m in utm_origin over the world origin change", drift);
+
+    if (drift > max_drift) {
+      RCLCPP_ERROR(node_->get_logger(), "the standing UAV moved by %.2f m in utm_origin, the tf reference was not re-anchored", drift);
+      return false;
+    }
+  }
+
+  // local_origin is anchored to the first uav_state, taken before the reset; once it is dropped the
+  // next uav_state re-anchors it onto the UAV, so the UAV ends up back at its origin
+  {
+    const double max_distance = 3.0; // [m]
+
+    auto position = positionInFrame(uav_name + "/local_origin");
+
+    if (!position) {
+      RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in local_origin after the world origin change");
+      return false;
+    }
+
+    const double distance = std::hypot(position.value().x, position.value().y);
+
+    RCLCPP_INFO(node_->get_logger(), "the UAV is %.2f m from local_origin after the world origin change", distance);
+
+    if (distance > max_distance) {
+      RCLCPP_ERROR(node_->get_logger(), "the UAV is %.2f m from local_origin, the frame was not re-anchored", distance);
+      return false;
+    }
+  }
+
+  // | --------- the safety area has to survive being rebuilt -------- |
+
+  // the manager rebuilds the zone from its own timer, a moment after it answers the service; wait
+  // for the shifted border to show up, otherwise the checks below still describe the old zone
+  {
+    const double min_shift = 1.0;  // [m]
+    const double timeout   = 20.0; // [s]
+
+    bool rebuilt = false;
+
+    const rclcpp::Time start = clock_->now();
+
+    while (rclcpp::ok() && (clock_->now() - start).seconds() < timeout) {
+
+      if (uh_->sh_safety_area_manager_diag_.hasMsg()) {
+
+        const auto border_now = uh_->sh_safety_area_manager_diag_.getMsg()->border.points;
+
+        if (border_now.size() == border_before.size() && !border_now.empty() &&
+            std::hypot(border_now[0].x - border_before[0].x, border_now[0].y - border_before[0].y) > min_shift) {
+          rebuilt = true;
+          break;
+        }
+      }
+
+      this->sleep(0.1);
+    }
+
+    if (!rebuilt) {
+      RCLCPP_ERROR(node_->get_logger(), "the safety area border did not move after the world origin changed, the zone was not rebuilt");
+      return false;
+    }
+  }
+
+  // a freshly constructed zone defaults to disabled; without carrying the state over, the fence
+  // silently disappears
+  {
+    auto response = sch_safety_zone_enabled.callSync(std::make_shared<mrs_msgs::srv::GetBoolSrv::Request>());
+
+    if (!response || !response.value()->value) {
+      RCLCPP_ERROR(node_->get_logger(), "the safety zone came back disabled after the world origin change");
+      return false;
+    }
+  }
+
+  // and it has to be enforced, not just reported as enabled
+  {
+    mrs_msgs::msg::ReferenceStamped msg;
+
+    msg.header.frame_id      = uav_name + "/world_origin";
+    msg.reference.position.x = 10000;
+    msg.reference.position.y = 10000;
+    msg.reference.position.z = 3;
+    msg.reference.heading    = 0;
+
+    auto [success, message] = uh_->validateReference(msg);
+
+    if (success) {
+      RCLCPP_ERROR(node_->get_logger(), "a reference 10 km away was accepted, the safety area is not enforced after the rebuild");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int main(int argc, char *argv[]) {
+
+  rclcpp::init(argc, argv);
+
+  bool test_result = true;
+
+  Tester tester;
+
+  test_result &= tester.test();
+
+  tester.sleep(2.0);
+
+  std::cout << "Test: reporting test results" << std::endl;
+
+  tester.reportTestResult(test_result);
+
+  tester.join();
+}

--- a/test/estimation_manager/set_world_origin_runtime/test.py
+++ b/test/estimation_manager/set_world_origin_runtime/test.py
@@ -1,0 +1,183 @@
+import time
+import unittest
+import os
+import sys
+
+import launch
+import launch_ros
+import launch_testing.actions
+import launch_testing.asserts
+from launch.actions import IncludeLaunchDescription, GroupAction, SetEnvironmentVariable, DeclareLaunchArgument
+import rclpy
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+
+from std_msgs.msg import Bool
+
+def generate_test_description():
+
+    SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp')
+
+    ld = launch.LaunchDescription()
+
+    launch_file_path = os.path.abspath(__file__)
+    launch_dir = os.path.dirname(launch_file_path)
+
+    test_name = os.path.basename(launch_dir)
+
+    uav_name="uav1"
+
+    platform_config=get_package_share_directory("mrs_multirotor_simulator")+"/config/mrs_uav_system/x500.yaml",
+
+    # ld.add_action(
+    #         launch_ros.actions.Node(
+    #             package='rmw_zenoh_cpp',
+    #             namespace='',
+    #             executable='rmw_zenohd',
+    #             name='zenoh_router',
+    #         )
+    #     )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                            'launch',
+                            'mrs_multirotor_simulator.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'custom_config': launch_dir+"/config/mrs_simulator.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                        'launch',
+                        'mrs_uav_system.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'run_automatic_start': "true",
+                        # 'standalone': "true",
+                        'uav_name': uav_name,
+                        'platform_config': platform_config,
+                        'world_config': launch_dir+"/config/world_config.yaml",
+                        'custom_config': launch_dir+"/config/custom_config.yaml",
+                        # 'automatic_start_config': launch_dir+"/config/automatic_start.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_multirotor_simulator'),
+                            'launch',
+                            'hw_api.launch.py'
+                        ])
+                    ]),
+                )
+            ]
+        )
+    )
+
+    # starts the integration interactor
+    ld.add_action(
+            # Nodes under test
+            launch_ros.actions.Node(
+                package='mrs_uav_managers',
+                namespace='',
+                executable='test_'+test_name,
+                name='test_'+test_name,
+                output="screen",
+                parameters=[
+                        {'test_name': test_name},
+                ],
+            )
+        )
+
+    # starts the python test part down below
+    ld.add_action(
+        launch.actions.TimerAction(
+            period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        )
+
+    return ld
+
+# #{ class PublisherHandlerTest(unittest.TestCase)
+
+class PublisherHandlerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('integration_test_handler')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_interactor(self, proc_output, timeout=120):
+
+        """Check whether pose messages published"""
+
+        test_result = []
+
+        sub = self.node.create_subscription(
+                Bool, '/test_result',
+                lambda msg: test_result.append(msg), 100)
+        try:
+
+            end_time = time.time() + timeout
+
+            while time.time() < end_time:
+
+                if len(test_result) > 0:
+                    break
+
+                rclpy.spin_once(self.node, timeout_sec=1)
+
+            time.sleep(2.0)
+
+            # check if we have the result
+            self.assertTrue(len(test_result) > 0)
+
+            # check if the result is true
+            self.assertTrue(test_result[0].data)
+
+        finally:
+            self.node.destroy_subscription(sub)
+
+# #} end of
+
+# #{ Post-shutdown tests
+
+# @launch_testing.post_shutdown_test()
+# class PublisherHandlerTestShutdown(unittest.TestCase):
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)
+
+# #} end of Post-shutdown tests


### PR DESCRIPTION
## Summary
- **What changed**:
  - **Re-anchor tf references after a runtime world-origin change**: `TfSource` (`include/transform_manager/tf_source.h`) gains `invalidateFirstMsg()`, which clears the cached first odometry message used to derive the utm/world tf offset. `TransformManager::callbackSetWorldOrigin` (`src/transform_manager/transform_manager.cpp`) now calls it on every tf source after `setWorldOrigin()`, forcing the utm/world tfs to recapture their reference in the new frame instead of keeping the stale one from before the estimator reset.
  - **Re-anchor `local_origin` after the same event**: the same callback also resets `is_first_frame_id_set_` and `is_local_static_tf_published_` to false, so `local_origin`'s static tf is republished anchored to the next `uav_state` rather than staying anchored to the pre-reset position. Both flags (plus `got_first_msg_` in `TfSource`) are changed to `std::atomic_bool` since they're now written from the service-callback path, not just the odometry-callback thread.
  - **Keep the safety fence enabled across a zone rebuild**: `SafetyAreaManager::createSafetyZone` (`src/safety_area_manager.cpp`) now calls `enableSafetyZone()` on the freshly built zone with the previous zone's enabled state, since a newly constructed `mrs_lib::SafetyZone` defaults to disabled.
- **Why**:
  - Previously, changing the world origin at runtime reset the estimators but left the utm/world tfs anchored to the pre-reset odometry reference, so they stayed offset by however far the origin moved.
  - Likewise, `local_origin` was anchored once to the first `uav_state` ever received; after a runtime origin change it kept describing the UAV's pre-reset position instead of re-centering on it.
  - `SafetyAreaManager` rebuilds a new zone object whenever the safety area needs to move with the origin. Without carrying the enabled flag forward, that rebuild silently dropped the fence — a live safety regression that produced no error or warning, only a geofence that stopped enforcing.
- **Notes for reviewers**:
  Test added; without fixes in this branch, the test fails. Test covers all the above-mentioned bugs.

## Impact
- **Affected areas**:
  - `TransformManager` (`src/transform_manager/transform_manager.cpp`, `include/transform_manager/tf_source.h`)
  - `SafetyAreaManager` (`src/safety_area_manager.cpp`)
  - Tests: new `test/estimation_manager/set_world_origin_runtime/`
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=true
export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
colcon test --packages-select mrs_uav_managers --ctest-args -R 'set_world_origin_runtime' --event-handlers console_direct+ console_stderr- console_start_end-
colcon test-result --all --verbose
# New test moves the world origin ~25 m at runtime while the UAV stands still, and checks: utm_origin doesn't drift, local_origin re-anchors to ~0, and the safety fence stays enabled and enforced after the zone rebuilds. 
# Verified 3/3 stable passes with all fixes applied (0.00 m drift both checks), and confirmed each fix individually necessary by reverting 5a29b60/5954ae2/b92829e one at a time and observing the test fail with the matching isolated symptom.