### PR TITLE
feat/ignore GNSS fixes reporting no fix

### DIFF
--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -832,6 +832,11 @@ void TransformManager::callbackGnss(const sensor_msgs::msg::NavSatFix::ConstShar
     return;
   }
 
+  if (msg->status.status == sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX) {
+    RCLCPP_ERROR_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: NavSatFix has no GNSS fix!!!", getPrintName().c_str());
+    return;
+  }
+
   geometry_msgs::msg::Point utm_origin;
   utm_origin.x = out_x;
   utm_origin.y = out_y;


### PR DESCRIPTION
## Summary
- **What changed**:
`TransformManager::callbackGnss` (`src/transform_manager/transform_manager.cpp`) now rejects a `NavSatFix` message whose `status.status` is `NavSatStatus::STATUS_NO_FIX`, right after the existing `isfinite` checks on the converted UTM `x`/`y`.
- **Why**:
`callbackGnss` validated the UTM-converted coordinates for NaNs but never checked the reported fix status, so a `NavSatFix` with `STATUS_NO_FIX` could still pass through. That matters because `utm_origin` is latched from the *first* GNSS message that clears these checks (`got_utm_offset_` is a one-shot latch) — if a no-fix reading with finite but meaningless lat/lon arrives before the receiver acquires a real fix, it permanently becomes `utm_origin`, and every frame derived from it (including `world_origin`) is offset from there on. `mrs_uav_state_estimators` already rejects the identical case when consuming the same GNSS data (`correction.h:1742`, right after the same three `isfinite` checks, same log text) — this mirrors that check so the transform manager and the estimator agree on what counts as a usable fix.
- **Notes for reviewers**:
The RTK path (`callbackRtkGps`) already gates on `RTK_FIX`, so only the GNSS path needed this. No test accompanies this fix — the simulator's GNSS source always reports a valid fix, so the no-fix path isn't reachable there.

## Impact
- **Affected areas**: `TransformManager` (`src/transform_manager/transform_manager.cpp`)
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [ ] Tested in simulation
    * [ ] Tested on real HW