### PR TITLE
feat(safety_area_manager)/do not rebuild the area when the origin does not move

### DIFF
--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -1158,9 +1158,19 @@ bool SafetyAreaManager::callbackUpdateWorldOrigin(const std::shared_ptr<mrs_msgs
   safety_zone_handler_.parameters.world_origin.y     = request->reference.position.y;
   safety_zone_handler_.parameters.world_origin.units = (request->header.frame_id.find("latlon_origin") != std::string::npos) ? "LATLON" : "UTM";
 
-  response->success     = true;
-  response->message     = "World origin set successfully";
-  world_origin_changed_ = true;
+  response->success = true;
+  response->message = "World origin set successfully";
+
+  // the area is defined in the world_origin frame and follows it through the tf, so a zero shift
+  // means the prisms would be rebuilt unchanged - skip it rather than tear down a correct zone.
+  // Re-sending the same origin cancels out exactly; the margin only absorbs rounding from the UTM
+  // conversions and is kept far below any shift that could matter, because failing to rebuild a
+  // genuinely moved area is the dangerous direction while an extra rebuild is not
+  const double min_significant_shift = 1e-3; // [m]
+
+  if (std::abs(delta_x) > min_significant_shift || std::abs(delta_y) > min_significant_shift) {
+    world_origin_changed_ = true;
+  }
 
   return true;
 }


### PR DESCRIPTION
## Summary
- **What changed**:
`SafetyAreaManager::callbackUpdateWorldOrigin` (`src/safety_area_manager.cpp:1161-1173`) now only sets `world_origin_changed_ = true` when the computed haversine offset (`delta_x`/`delta_y`) exceeds a `1e-3` m threshold. Previously, it was set unconditionally on every call, regardless of whether the origin actually moved.
- **Why**:
If the safety area is defined in the `world_origin` frame and position checks transform *into* that frame, so the zone already follows the origin through the tf without its stored points needing to change. Re-sending the same origin (or a bit-for-bit-equal one in a different representation, e.g. UTM vs latlon) produces a zero (or near-zero, floating-point-rounding) shift, yet `world_origin_changed_` was still raised, and the downstream rebuild path (`safety_area_manager.cpp:607`) tore down and reconstructed the entire zone with `+0` added to every point — a geometric no-op that needlessly discarded a correct, already-built zone (and briefly re-triggers the zone-disabled risk that `fix/world-origin-runtime-change` addresses, since every rebuild reconstructs a fresh `SafetyZone` object). The `1e-3` m margin absorbs UTM-conversion rounding, not genuine motion — it's kept far below any shift that could matter, because failing to rebuild a genuinely moved area is the dangerous direction, whereas an unneeded rebuild merely wastes work.
- **Notes for reviewers**:

## Impact
- **Affected areas**: `SafetyAreaManager` (`src/safety_area_manager.cpp`)
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [ ] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=true
# Build-only verification. Behavioral confirmation would require observing that the zone's border-point identity (or a rebuild counter/log) is unchanged across a re-sent, unmoved world origin — not currently exposed through the test API.