### PR TITLE
tests: retry the tf lookup in set_world_origin_runtime

### DIFF
--- a/test/estimation_manager/set_world_origin_runtime/test.cpp
+++ b/test/estimation_manager/set_world_origin_runtime/test.cpp
@@ -22,6 +22,7 @@ public:
 
 private:
   std::optional<geometry_msgs::msg::Point> positionInFrame(const std::string &frame);
+  std::optional<geometry_msgs::msg::Point> waitForPositionInFrame(const std::string &frame, const double timeout);
 };
 
 /* positionInFrame() //{ */
@@ -48,6 +49,32 @@ std::optional<geometry_msgs::msg::Point> Tester::positionInFrame(const std::stri
   }
 
   return tfed->reference.position;
+}
+
+//}
+
+/* waitForPositionInFrame() //{ */
+
+// positionInFrame() can fail right after the system reports ready, before every static tf (e.g.
+// local_origin) has actually been broadcast yet; poll instead of querying once
+std::optional<geometry_msgs::msg::Point> Tester::waitForPositionInFrame(const std::string &frame, const double timeout) {
+
+  const rclcpp::Time start = clock_->now();
+
+  while (rclcpp::ok() && (clock_->now() - start).seconds() < timeout) {
+
+    auto position = positionInFrame(frame);
+
+    if (position) {
+      return position;
+    }
+
+    RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for the transform to '%s'", frame.c_str());
+
+    this->sleep(0.1);
+  }
+
+  return std::nullopt;
 }
 
 //}
@@ -107,7 +134,7 @@ bool Tester::test(void) {
   geometry_msgs::msg::Point utm_before;
 
   {
-    auto position = positionInFrame(uav_name + "/utm_origin");
+    auto position = waitForPositionInFrame(uav_name + "/utm_origin", 5.0);
 
     if (!position) {
       RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in utm_origin before the world origin change");
@@ -148,7 +175,7 @@ bool Tester::test(void) {
   {
     const double max_drift = 2.0; // [m]
 
-    auto position = positionInFrame(uav_name + "/utm_origin");
+    auto position = waitForPositionInFrame(uav_name + "/utm_origin", 5.0);
 
     if (!position) {
       RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in utm_origin after the world origin change");
@@ -170,7 +197,7 @@ bool Tester::test(void) {
   {
     const double max_distance = 3.0; // [m]
 
-    auto position = positionInFrame(uav_name + "/local_origin");
+    auto position = waitForPositionInFrame(uav_name + "/local_origin", 5.0);
 
     if (!position) {
       RCLCPP_ERROR(node_->get_logger(), "could not get the UAV position in local_origin after the world origin change");


### PR DESCRIPTION
## Summary
- **What changed**:
`test/estimation_manager/set_world_origin_runtime/test.cpp` gains `waitForPositionInFrame()`, a bounded (5s) poll wrapper around the existing `positionInFrame()` tf lookup. Applied at all three call sites where the test queries the UAV's position in a frame (`utm_origin` before the origin change, `utm_origin` and `local_origin` after it).
- **Why**:
`positionInFrame()` could be queried right after `mrsSystemReady()` returns but before every static tf (e.g. `local_origin`) had actually been broadcast yet, failing the test outright on a startup race completely unrelated to the world-origin-change logic the test is meant to guard. Observed at roughly 1-in-5 runs. 
- **Notes for reviewers**:
Verified the race actually happens and is absorbed, not just "didn't happen to trigger": added a throttled log on the retry path, then across 14 runs the retry fired in 3 of them — logging exactly `waiting for the transform to '.../utm_origin'` on the same first, pre-change query that used to fail outright — and all three still passed with the expected `0.00 m` measurements. 14/14 runs green overall, and the measured drift values are unchanged, so the three fixes this test discriminates on (`fix/world-origin-runtime-change`, already merged) are still correctly guarded.

## Impact
- **Affected areas**: `test/estimation_manager/set_world_origin_runtime/test.cpp` only — test infrastructure, no production code touched.
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=true
export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
colcon test --packages-select mrs_uav_managers --ctest-args -R 'set_world_origin_runtime' --event-handlers console_direct+ console_stderr- console_start_end-
colcon test-result --all --verbose
# ran 14x in a row to confirm both no regression in the test's discrimination (drift stayed 0.00 m)
# and that the retry path genuinely engages under the original race (fired in 3/14 runs, all passed)