### PR TITLE
fix(safety_area_manager): correct world_origin offset sign corrupting the safety zone

### DIFF
--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -653,6 +653,10 @@ void SafetyAreaManager::timerStatus() {
       if (new_safety_zone) {
         safety_zone_handler_.visualization_components.safeCleanup();
         safety_zone_handler_ = std::move(*new_safety_zone);
+
+        // consumed: clear it so it isn't applied again on the next rebuild
+        world_origin_offset_x_ = 0.0;
+        world_origin_offset_y_ = 0.0;
       } else {
         RCLCPP_ERROR(node_->get_logger(), "Failed to update safety area after world origin change.");
         error_publisher_->addOneshotError("Failed to update safety area after world origin change.");
@@ -1166,8 +1170,9 @@ bool SafetyAreaManager::callbackUpdateWorldOrigin(const std::shared_ptr<mrs_msgs
     delta_y = new_utm_y - old_utm_y;
   }
 
-  world_origin_offset_x_ = delta_x;
-  world_origin_offset_y_ = delta_y;
+  // accumulate: an earlier call's shift may not be consumed by timerStatus() yet
+  world_origin_offset_x_ += delta_x;
+  world_origin_offset_y_ += delta_y;
 
   RCLCPP_INFO(node_->get_logger(), "World origin shifted by dx: %.2f dy: %.2f meters", delta_x, delta_y);
 
@@ -1185,7 +1190,8 @@ bool SafetyAreaManager::callbackUpdateWorldOrigin(const std::shared_ptr<mrs_msgs
   // genuinely moved area is the dangerous direction while an extra rebuild is not
   const double min_significant_shift = 1e-3; // [m]
 
-  if (std::abs(delta_x) > min_significant_shift || std::abs(delta_y) > min_significant_shift) {
+  // checked on the accumulated offset so sub-threshold shifts still add up to trigger a rebuild
+  if (std::abs(world_origin_offset_x_) > min_significant_shift || std::abs(world_origin_offset_y_) > min_significant_shift) {
     world_origin_changed_ = true;
   }
 

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -607,56 +607,59 @@ void SafetyAreaManager::timerStatus() {
     }
   }
 
-  auto current_border = safety_zone_handler_.safety_zone->getBorder();
-
-  if (world_origin_changed_ && current_border.getHorizontalFrame() == "world_origin") {
-    RCLCPP_INFO(node_->get_logger(), "World origin has changed, updating the safety area accordingly.");
-
+  {
+    // callbackUpdateWorldOrigin mutates these under the same mutex
     std::scoped_lock lock(mutex_safety_area_);
 
-    auto current_frame  = current_border.getHorizontalFrame();
-    auto current_points = current_border.getPoints();
-    auto current_min_z  = current_border.getMinZ();
-    auto current_max_z  = current_border.getMaxZ();
+    auto current_border = safety_zone_handler_.safety_zone->getBorder();
 
-    std::vector<mrs_lib::safety_zone::Point2d> new_points;
+    if (world_origin_changed_ && current_border.getHorizontalFrame() == "world_origin") {
+      RCLCPP_INFO(node_->get_logger(), "World origin has changed, updating the safety area accordingly.");
 
-    // world_origin already moved by +offset; subtract it here to keep the point physically fixed
-    for (auto &point : current_points) {
-      new_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
-    }
+      auto current_frame  = current_border.getHorizontalFrame();
+      auto current_points = current_border.getPoints();
+      auto current_min_z  = current_border.getMinZ();
+      auto current_max_z  = current_border.getMaxZ();
 
-    auto new_border_prism = std::make_unique<mrs_lib::safety_zone::Prism>(new_points, current_max_z, current_min_z, "world_origin", "world_origin");
+      std::vector<mrs_lib::safety_zone::Point2d> new_points;
 
-    // Add existing obstacles with updated positions
-    auto existing_obstacles = copyExistingObstacles();
-
-    // Check if obstacles defined in world_origin frame
-    for (auto &obstacle : existing_obstacles) {
-      if (obstacle->getHorizontalFrame() == "world_origin") {
-        auto                                       obstacle_points = obstacle->getPoints();
-        std::vector<mrs_lib::safety_zone::Point2d> updated_points;
-
-        for (auto &point : obstacle_points) {
-          updated_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
-        }
-
-        *obstacle = mrs_lib::safety_zone::Prism(updated_points, obstacle->getMaxZ(), obstacle->getMinZ(), "world_origin", "world_origin");
+      // world_origin already moved by +offset; subtract it here to keep the point physically fixed
+      for (auto &point : current_points) {
+        new_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
       }
+
+      auto new_border_prism = std::make_unique<mrs_lib::safety_zone::Prism>(new_points, current_max_z, current_min_z, "world_origin", "world_origin");
+
+      // Add existing obstacles with updated positions
+      auto existing_obstacles = copyExistingObstacles();
+
+      // Check if obstacles defined in world_origin frame
+      for (auto &obstacle : existing_obstacles) {
+        if (obstacle->getHorizontalFrame() == "world_origin") {
+          auto                                       obstacle_points = obstacle->getPoints();
+          std::vector<mrs_lib::safety_zone::Point2d> updated_points;
+
+          for (auto &point : obstacle_points) {
+            updated_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
+          }
+
+          *obstacle = mrs_lib::safety_zone::Prism(updated_points, obstacle->getMaxZ(), obstacle->getMinZ(), "world_origin", "world_origin");
+        }
+      }
+
+      auto new_safety_zone = createSafetyZone(std::move(new_border_prism), std::move(existing_obstacles));
+
+      // Update the new safety zone and visualization components
+      if (new_safety_zone) {
+        safety_zone_handler_.visualization_components.safeCleanup();
+        safety_zone_handler_ = std::move(*new_safety_zone);
+      } else {
+        RCLCPP_ERROR(node_->get_logger(), "Failed to update safety area after world origin change.");
+        error_publisher_->addOneshotError("Failed to update safety area after world origin change.");
+      }
+
+      world_origin_changed_ = false;
     }
-
-    auto new_safety_zone = createSafetyZone(std::move(new_border_prism), std::move(existing_obstacles));
-
-    // Update the new safety zone and visualization components
-    if (new_safety_zone) {
-      safety_zone_handler_.visualization_components.safeCleanup();
-      safety_zone_handler_ = std::move(*new_safety_zone);
-    } else {
-      RCLCPP_ERROR(node_->get_logger(), "Failed to update safety area after world origin change.");
-      error_publisher_->addOneshotError("Failed to update safety area after world origin change.");
-    }
-
-    world_origin_changed_ = false;
   }
 
   // Publishing

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -621,9 +621,9 @@ void SafetyAreaManager::timerStatus() {
 
     std::vector<mrs_lib::safety_zone::Point2d> new_points;
 
-    // Add offset to border points
+    // world_origin already moved by +offset; subtract it here to keep the point physically fixed
     for (auto &point : current_points) {
-      new_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() + world_origin_offset_x_, point.get<1>() + world_origin_offset_y_});
+      new_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
     }
 
     auto new_border_prism = std::make_unique<mrs_lib::safety_zone::Prism>(new_points, current_max_z, current_min_z, "world_origin", "world_origin");
@@ -638,7 +638,7 @@ void SafetyAreaManager::timerStatus() {
         std::vector<mrs_lib::safety_zone::Point2d> updated_points;
 
         for (auto &point : obstacle_points) {
-          updated_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() + world_origin_offset_x_, point.get<1>() + world_origin_offset_y_});
+          updated_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
         }
 
         *obstacle = mrs_lib::safety_zone::Prism(updated_points, obstacle->getMaxZ(), obstacle->getMinZ(), "world_origin", "world_origin");

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -616,10 +616,10 @@ void SafetyAreaManager::timerStatus() {
     if (world_origin_changed_ && current_border.getHorizontalFrame() == "world_origin") {
       RCLCPP_INFO(node_->get_logger(), "World origin has changed, updating the safety area accordingly.");
 
-      auto current_frame  = current_border.getHorizontalFrame();
-      auto current_points = current_border.getPoints();
-      auto current_min_z  = current_border.getMinZ();
-      auto current_max_z  = current_border.getMaxZ();
+      auto current_v_frame = current_border.getVerticalFrame();
+      auto current_points  = current_border.getPoints();
+      auto current_min_z   = current_border.getMinZ();
+      auto current_max_z   = current_border.getMaxZ();
 
       std::vector<mrs_lib::safety_zone::Point2d> new_points;
 
@@ -628,7 +628,7 @@ void SafetyAreaManager::timerStatus() {
         new_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
       }
 
-      auto new_border_prism = std::make_unique<mrs_lib::safety_zone::Prism>(new_points, current_max_z, current_min_z, "world_origin", "world_origin");
+      auto new_border_prism = std::make_unique<mrs_lib::safety_zone::Prism>(new_points, current_max_z, current_min_z, "world_origin", current_v_frame);
 
       // Add existing obstacles with updated positions
       auto existing_obstacles = copyExistingObstacles();
@@ -643,7 +643,7 @@ void SafetyAreaManager::timerStatus() {
             updated_points.push_back(mrs_lib::safety_zone::Point2d{point.get<0>() - world_origin_offset_x_, point.get<1>() - world_origin_offset_y_});
           }
 
-          *obstacle = mrs_lib::safety_zone::Prism(updated_points, obstacle->getMaxZ(), obstacle->getMinZ(), "world_origin", "world_origin");
+          *obstacle = mrs_lib::safety_zone::Prism(updated_points, obstacle->getMaxZ(), obstacle->getMinZ(), "world_origin", obstacle->getVerticalFrame());
         }
       }
 

--- a/test/estimation_manager/set_world_origin_runtime/config/custom_config.yaml
+++ b/test/estimation_manager/set_world_origin_runtime/config/custom_config.yaml
@@ -9,20 +9,8 @@ mrs_uav_managers:
 
     # loaded state estimator plugins
     state_estimators: [
-      "gps_baro",
       "gps_garmin",
-      # "rtk",
-      # "rtk_garmin",
-      "passthrough",
     ]
 
-    initial_state_estimator: "gps_baro" # will be used as the first state estimator
-    agl_height_estimator: "" # only slightly filtered height for checking min height (not used in control feedback)
-
-  uav_manager:
-
-    midair_activation:
-
-      after_activation:
-        controller: "Se3Controller"
-        tracker: "MpcTracker"
+    initial_state_estimator: "gps_garmin" # will be used as the first state estimator
+    agl_height_estimator: "garmin_agl" # only slightly filtered height for checking min height (not used in control feedback)

--- a/test/estimation_manager/set_world_origin_runtime/config/world_config.yaml
+++ b/test/estimation_manager/set_world_origin_runtime/config/world_config.yaml
@@ -31,12 +31,45 @@ mrs_uav_managers:
         ]
       vertical:
 
-        # the frame of reference in which the max&min z is expressed
-        frame_name: "world_origin"
+        frame_name: "local_origin" # not "world_origin": must survive a world_origin change untouched
 
         max_z: 15.0
         min_z: 0.5
 
       obstacles:
 
-        present: false
+        present: true # obstacle_0: latlon_origin (untouched), obstacle_1: world_origin (shifts)
+
+    obstacles:
+
+      count: 2
+
+      obstacle_0:
+
+        horizontal:
+          frame_name: "latlon_origin"
+          points: [
+            47.402543, 8.545394,
+            47.402543, 8.545794,
+            47.402943, 8.545794,
+            47.402943, 8.545394,
+          ]
+        vertical:
+          frame_name: "world_origin"
+          max_z: 10.0
+          min_z: 1.0
+
+      obstacle_1:
+
+        horizontal:
+          frame_name: "world_origin"
+          points: [
+            60, 60,
+            60, 70,
+            70, 70,
+            70, 60,
+          ]
+        vertical:
+          frame_name: "local_origin"
+          max_z: 10.0
+          min_z: 1.0

--- a/test/estimation_manager/set_world_origin_runtime/test.cpp
+++ b/test/estimation_manager/set_world_origin_runtime/test.cpp
@@ -1,6 +1,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/time.hpp>
 
+#include <mrs_lib/gps_conversions.h>
 #include <mrs_lib/service_client_handler.h>
 
 #include <mrs_msgs/srv/get_bool_srv.hpp>
@@ -83,6 +84,10 @@ bool Tester::test(void) {
 
   const std::string uav_name = "uav1";
 
+  // ~25 m from the configured origin: far enough that an un-anchored frame is unmistakable
+  const double new_origin_lat = 47.397923;
+  const double new_origin_lon = 8.545794;
+
   {
     auto [uhopt, message] = getUAVHandler(uav_name);
 
@@ -98,6 +103,9 @@ bool Tester::test(void) {
 
   auto sch_safety_zone_enabled =
       mrs_lib::ServiceClientHandler<mrs_msgs::srv::GetBoolSrv>(node_, "/" + uav_name + "/safety_area_manager/is_safety_zone_enabled");
+
+  auto sch_point_in_safety_area_2d =
+      mrs_lib::ServiceClientHandler<mrs_msgs::srv::ReferenceStampedSrv>(node_, "/" + uav_name + "/safety_area_manager/point_in_safety_area_2d");
 
   // | ---- wait for the system, the origin can only be set on the ground ---- |
 
@@ -116,16 +124,44 @@ bool Tester::test(void) {
     }
   }
 
-  // remember the border, the rebuild is detected by it moving with the origin
+  // remember the border and origin, so the expected shift below can be computed exactly
   std::vector<mrs_msgs::msg::Point2D> border_before;
+  std::string                         border_vertical_frame_before;
+  std::vector<mrs_msgs::msg::Prism>   obstacles_before;
+  double                              origin_lat_before = 0.0;
+  double                              origin_lon_before = 0.0;
 
   if (uh_->sh_safety_area_manager_diag_.hasMsg()) {
-    border_before = uh_->sh_safety_area_manager_diag_.getMsg()->border.points;
+    const auto diag              = uh_->sh_safety_area_manager_diag_.getMsg();
+    border_before                = diag->border.points;
+    border_vertical_frame_before = diag->border.vertical_frame;
+    obstacles_before             = diag->obstacles;
+    origin_lat_before            = diag->world_origin.x;
+    origin_lon_before            = diag->world_origin.y;
   }
 
   if (border_before.empty()) {
     RCLCPP_ERROR(node_->get_logger(), "no safety area border received before the world origin change");
     return false;
+  }
+
+  // obstacle_0 is latlon_origin (untouched), obstacle_1 is world_origin (shifts like the border)
+  if (obstacles_before.size() != 2 || obstacles_before[0].points.empty() || obstacles_before[1].points.empty()) {
+    RCLCPP_ERROR(node_->get_logger(), "expected exactly two obstacles with points before the world origin change");
+    return false;
+  }
+
+  // the origin point (0, 0) - which this border is centered on - must be inside it
+  {
+    auto request             = std::make_shared<mrs_msgs::srv::ReferenceStampedSrv::Request>();
+    request->header.frame_id = uav_name + "/world_origin";
+
+    auto response = sch_point_in_safety_area_2d.callSync(request);
+
+    if (!response || !response.value()->success) {
+      RCLCPP_ERROR(node_->get_logger(), "the safety area center is not enforced as valid before the world origin change");
+      return false;
+    }
   }
 
   // the UAV stands still for the whole test, so utm_origin - a frame the origin change must not
@@ -151,11 +187,9 @@ bool Tester::test(void) {
   {
     auto request = std::make_shared<mrs_msgs::srv::ReferenceStampedSrv::Request>();
 
-    request->header.frame_id = "latlon_origin";
-    // ~25 m from the configured origin: far enough that a frame left un-anchored is unmistakable
-    // (it lands megametres away), close enough to keep the UAV well inside the safety area
-    request->reference.position.x = 47.397923;
-    request->reference.position.y = 8.545794;
+    request->header.frame_id      = "latlon_origin";
+    request->reference.position.x = new_origin_lat;
+    request->reference.position.y = new_origin_lon;
 
     auto response = sch_set_world_origin.callSync(request);
 
@@ -216,8 +250,16 @@ bool Tester::test(void) {
 
   // | --------- the safety area has to survive being rebuilt -------- |
 
+  // a physically-fixed border must shift by exactly -(new_utm - old_utm), catching a sign error
+  double old_utm_x, old_utm_y, new_utm_x, new_utm_y;
+  mrs_lib::UTM(origin_lat_before, origin_lon_before, &old_utm_x, &old_utm_y);
+  mrs_lib::UTM(new_origin_lat, new_origin_lon, &new_utm_x, &new_utm_y);
+  const double expected_delta_x = new_utm_x - old_utm_x;
+  const double expected_delta_y = new_utm_y - old_utm_y;
+
   // the manager rebuilds the zone from its own timer, a moment after it answers the service; wait
   // for the shifted border to show up, otherwise the checks below still describe the old zone
+  std::vector<mrs_msgs::msg::Point2D> border_now;
   {
     const double min_shift = 1.0;  // [m]
     const double timeout   = 20.0; // [s]
@@ -230,11 +272,12 @@ bool Tester::test(void) {
 
       if (uh_->sh_safety_area_manager_diag_.hasMsg()) {
 
-        const auto border_now = uh_->sh_safety_area_manager_diag_.getMsg()->border.points;
+        const auto candidate = uh_->sh_safety_area_manager_diag_.getMsg()->border.points;
 
-        if (border_now.size() == border_before.size() && !border_now.empty() &&
-            std::hypot(border_now[0].x - border_before[0].x, border_now[0].y - border_before[0].y) > min_shift) {
-          rebuilt = true;
+        if (candidate.size() == border_before.size() && !candidate.empty() &&
+            std::hypot(candidate[0].x - border_before[0].x, candidate[0].y - border_before[0].y) > min_shift) {
+          border_now = candidate;
+          rebuilt    = true;
           break;
         }
       }
@@ -244,6 +287,92 @@ bool Tester::test(void) {
 
     if (!rebuilt) {
       RCLCPP_ERROR(node_->get_logger(), "the safety area border did not move after the world origin changed, the zone was not rebuilt");
+      return false;
+    }
+  }
+
+  // the shift has to match -expected_delta exactly (within UTM/float rounding), not just be nonzero
+  {
+    const double tol = 1e-2; // [m]
+
+    for (size_t i = 0; i < border_now.size(); i++) {
+      const double expected_x = border_before[i].x - expected_delta_x;
+      const double expected_y = border_before[i].y - expected_delta_y;
+      const double error_x    = std::abs(border_now[i].x - expected_x);
+      const double error_y    = std::abs(border_now[i].y - expected_y);
+
+      if (error_x > tol || error_y > tol) {
+        RCLCPP_ERROR(node_->get_logger(),
+                     "border point %zu shifted to (%.3f, %.3f), expected (%.3f, %.3f) - wrong sign or magnitude in the world_origin compensation", i,
+                     border_now[i].x, border_now[i].y, expected_x, expected_y);
+        return false;
+      }
+    }
+  }
+
+  // vertical frame (local_origin, deliberately not world_origin) must survive the rebuild
+  {
+    const auto border_vertical_frame_now = uh_->sh_safety_area_manager_diag_.getMsg()->border.vertical_frame;
+
+    if (border_vertical_frame_now != border_vertical_frame_before) {
+      RCLCPP_ERROR(node_->get_logger(), "the border's vertical frame changed from '%s' to '%s' after the world origin change",
+                   border_vertical_frame_before.c_str(), border_vertical_frame_now.c_str());
+      return false;
+    }
+  }
+
+  // exercises both branches of the per-obstacle rebuild
+  {
+    const auto obstacles_now = uh_->sh_safety_area_manager_diag_.getMsg()->obstacles;
+
+    if (obstacles_now.size() != 2 || obstacles_now[0].points.size() != obstacles_before[0].points.size() ||
+        obstacles_now[1].points.size() != obstacles_before[1].points.size()) {
+      RCLCPP_ERROR(node_->get_logger(), "an obstacle changed shape after the world origin change");
+      return false;
+    }
+
+    for (size_t i = 0; i < obstacles_now[0].points.size(); i++) {
+      if (obstacles_now[0].points[i].x != obstacles_before[0].points[i].x || obstacles_now[0].points[i].y != obstacles_before[0].points[i].y) {
+        RCLCPP_ERROR(node_->get_logger(), "the latlon_origin obstacle point %zu moved after the world origin change, but it is not in world_origin frame", i);
+        return false;
+      }
+    }
+
+    if (obstacles_now[1].vertical_frame != obstacles_before[1].vertical_frame) {
+      RCLCPP_ERROR(node_->get_logger(), "the world_origin obstacle's vertical frame changed from '%s' to '%s' after the world origin change",
+                   obstacles_before[1].vertical_frame.c_str(), obstacles_now[1].vertical_frame.c_str());
+      return false;
+    }
+
+    const double tol = 1e-2; // [m]
+
+    for (size_t i = 0; i < obstacles_now[1].points.size(); i++) {
+      const double expected_x = obstacles_before[1].points[i].x - expected_delta_x;
+      const double expected_y = obstacles_before[1].points[i].y - expected_delta_y;
+      const double error_x    = std::abs(obstacles_now[1].points[i].x - expected_x);
+      const double error_y    = std::abs(obstacles_now[1].points[i].y - expected_y);
+
+      if (error_x > tol || error_y > tol) {
+        RCLCPP_ERROR(
+            node_->get_logger(),
+            "world_origin obstacle point %zu shifted to (%.3f, %.3f), expected (%.3f, %.3f) - wrong sign or magnitude in the world_origin compensation", i,
+            obstacles_now[1].points[i].x, obstacles_now[1].points[i].y, expected_x, expected_y);
+        return false;
+      }
+    }
+  }
+
+  // the same physical point, re-expressed in the new frame, must still be enforced as valid
+  {
+    auto request                  = std::make_shared<mrs_msgs::srv::ReferenceStampedSrv::Request>();
+    request->header.frame_id      = uav_name + "/world_origin";
+    request->reference.position.x = -expected_delta_x;
+    request->reference.position.y = -expected_delta_y;
+
+    auto response = sch_point_in_safety_area_2d.callSync(request);
+
+    if (!response || !response.value()->success) {
+      RCLCPP_ERROR(node_->get_logger(), "the safety area center is no longer enforced as valid after the world origin change");
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- **What changed**:
  - **Sign fix**: `timerStatus()`'s world_origin-frame border/obstacle rebuild subtracted `world_origin_offset_x_/y_` instead of adding it. The `world_origin` tf frame itself already moves by `+offset` when the origin changes, so re-applying `+offset` to the stored points doubled the drift.
  - **Mutex fix**: `world_origin_offset_x_/y_` and `current_border` are now read inside `mutex_safety_area_`'s scope for the whole rebuild block, instead of one line before the lock was acquired — the read raced `callbackUpdateWorldOrigin`, which writes the same state from a separate `MutuallyExclusive` callback group (services vs. timers) under the multi-threaded executor.
  - **Vertical-frame fix**: the rebuild hardcoded the new border/obstacle prisms' vertical frame to `"world_origin"`, discarding whatever was actually configured (e.g. `"local_origin"`). It now threads the previous vertical frame through via `getVerticalFrame()`.
  - **Accumulate fix**: `callbackUpdateWorldOrigin` overwrote `world_origin_offset_x_/y_` on every call; a second world-origin change arriving before `timerStatus()` consumed the first one silently dropped it. The offset is now accumulated with `+=` and cleared only once `timerStatus()` actually applies it to a rebuilt zone.
  - **Test**: `set_world_origin_runtime` now covers two obstacles (one `latlon_origin`, one `world_origin`) with exact-shift, enforcement, and vertical-frame-preservation assertions, instead of only checking that the border moved. Each assertion was confirmed to fail when its corresponding fix above is reverted.
- **Why**:
  - A user reported that PR #48 (https://github.com/ctu-mrs/mrs_uav_managers/pull/48) "broke rviz visualization of the safety area" after a runtime world-origin change. Investigation found this is not a visualization bug: the sign error corrupts `isPointInSafetyArea2d/3d`'s actual enforcement, since it reads the same rebuilt zone object.
  - The bug was introduced in `aa45ab3` ("Improving safety area manager", 2025-12-08) and predates PR #48 by ~7.5 months. It went unnoticed because `use_home_position`'s first-adoption path always forces `delta=0`, and no test exercised a runtime world-origin change with a nonzero delta until PR #44 (https://github.com/ctu-mrs/mrs_uav_managers/pull/44) added the first one.
- **Notes for reviewers**:
  - Split into one commit per fix (sign / mutex / vertical-frame / accumulate) plus separate commits for the test expansion and a test-config cleanup, so each mechanism can be reviewed independently. All 4 fixes land in the same function (`timerStatus()`) and are mechanically entangled by re-indentation, so read them in order rather than expecting each commit's diff to be self-contained context.
  - The same "unlocked read across callback groups" bug shape was independently fixed twice before in this file/area (`8d5a46c`, and `766d0bb` in `transform_manager.cpp`) — this is a third occurrence, now with the mutex scope widened to cover the whole read+rebuild sequence rather than just the write.

## Impact
- **Affected areas**:
  - `SafetyAreaManager` (`src/safety_area_manager.cpp`) — `timerStatus()` and `callbackUpdateWorldOrigin()`
  - Test: `test/estimation_manager/set_world_origin_runtime/` (`test.cpp`, `config/world_config.yaml`, `config/custom_config.yaml`)
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
cd ~/workspace && colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=ON
export RMW_IMPLEMENTATION=rmw_zenoh_cpp
colcon test --packages-select mrs_uav_managers \
  --ctest-args -R 'test_estimation_manager_set_world_origin_runtime_test.py' \
  --event-handlers console_direct+ console_stderr- console_start_end-
# passed repeatedly across this session, including after reverting each
# individual fix in isolation to confirm the corresponding assertion fails
```