### PR TITLE
fix(transform_manager): keep only heading when latching local_origin

### DIFF
--- a/src/transform_manager/transform_manager.cpp
+++ b/src/transform_manager/transform_manager.cpp
@@ -1327,7 +1327,23 @@ void TransformManager::publishLocalTf() {
   tf_msg.header.frame_id       = ns_fixed_origin_child_frame_id_;
   tf_msg.child_frame_id        = ns_local_origin_child_frame_id_;
   tf_msg.transform.translation = Support::pointToVector3(pose_first_.pose.position);
-  tf_msg.transform.rotation    = pose_first_.pose.orientation;
+
+  // local_origin must be gravity-aligned and only yawed to the heading at the UAV's initial
+  // position. pose_first_ is the first uav_state - latched once at startup, never re-latched on
+  // takeoff - whose orientation also carries the roll and pitch the estimator reported at that
+  // instant: nonzero from ground slope, an unconverged attitude estimate, or an IMU mount offset.
+  // This tf is static, so latching the full orientation would tilt local_origin for the whole
+  // session, and the tilt turns into a position error that grows with distance from the
+  // local_origin origin. Take the heading only.
+  double heading;
+  try {
+    heading = mrs_lib::AttitudeConverter(pose_first_.pose.orientation).getHeading();
+  }
+  catch (...) {
+    RCLCPP_ERROR(node_->get_logger(), "[%s]: Exception caught during getting heading, not latching local_origin yet", getPrintName().c_str());
+    return;
+  }
+  tf_msg.transform.rotation = mrs_lib::AttitudeConverter(0, 0, heading);
 
   if (Support::noNans(tf_msg)) {
 


### PR DESCRIPTION
## Summary
- **What changed**:
  - `TransformManager::publishLocalTf()` built the static `fixed_origin -> local_origin` transform with `tf_msg.transform.rotation = pose_first_.pose.orientation` — the full orientation of the first `uav_state`.
  - It now extracts the heading only (`mrs_lib::AttitudeConverter(pose_first_.pose.orientation).getHeading()`) and rebuilds a gravity-aligned, heading-only quaternion (`mrs_lib::AttitudeConverter(0, 0, heading)`). Translation (first-pose position) is unchanged.
  - On a `getHeading()` exception it logs and returns without latching, so the one-shot publish retries on the next `uav_state` — the same failure handling as `publishFcuUntiltedTf` in this file.
- **Why**:
  - `pose_first_.pose.orientation` also carries the roll and pitch the estimator reported at that first instant — nonzero from ground slope, an unconverged attitude estimate, or an IMU mount offset.
  - This transform is static and is re-latched only on a node restart or a runtime `set_world_origin` (not on land/takeoff), so the tilt was frozen for the whole session, every flight.
  - `local_origin` is meant to be gravity-aligned and only yawed to the initial heading. A frozen tilt of angle theta produces a position error of `distance * sin(theta)` for anything expressed in `local_origin`, growing with distance from the frame origin.
  - Seen on a real-drone rosbag: first-pose roll -1.7 deg / pitch +2.3 deg, and a safety area expressed relative to `local_origin` rendered visibly displaced and canted.
- **Notes for reviewers**:
  - The heading extraction and the `catch -> RCLCPP_ERROR -> return` both mirror `publishFcuUntiltedTf()` (same file), which already does heading-only handling.

## Impact
- **Affected areas**:
  - `TransformManager` (`src/transform_manager/transform_manager.cpp`), `publishLocalTf()`
- **Breaking changes**: No
  - `local_origin` becomes level instead of tilted only when the first `uav_state` had nonzero roll/pitch.
  - RViz is unaffected — the deployment default fixed frame is `fixed_origin` (`mrs_uav_deployment/config/rviz/default.rviz`), and nothing resolves display through `local_origin`.
  - Consumers that read positions in `local_origin` (local-frame safety areas, the `republish_in_frames: ["local_origin"]` odometry, operator references in `local_origin`) get corrected values

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_uav_managers --cmake-args -DENABLE_TESTS=1
colcon test --packages-select mrs_uav_managers --ctest-args -R \
'reference_local_origin_service|takeoff_world_origin_home_position|set_world_origin_runtime|switch_estimator_world_origin_home_position|takeoff_service' \
  -p 1 --event-handlers console_direct+
```