### PR TITLE
fix(safety_area_manager): visualize the safety zone in its own frame, not local_origin

### DIFF
--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -230,6 +230,8 @@ private:
                                                          const std::string &horizontal_frame, const std::string &vertical_frame);
   // Transform prism
   std::optional<mrs_lib::safety_zone::Prism> transformPrism(const mrs_lib::safety_zone::Prism &prism, const std::string &target_frame);
+  // frame a prism is visualized in: its own horizontal frame, with latlon_origin remapped to world_origin for RViz
+  std::string visualizationFrame(const mrs_lib::safety_zone::Prism &prism);
 
   std::tuple<bool, std::vector<mrs_lib::safety_zone::Point2d>> transformPoints(const std::vector<mrs_lib::safety_zone::Point2d> &points,
                                                                                const std::string &from_frame, const std::string &target_frame);
@@ -568,34 +570,35 @@ void SafetyAreaManager::timerStatus() {
     return;
   }
 
-  // RViz Visualizations, only once we have the safety zone defined and there is a transform available to the local_origin frame.
+  // RViz visualization: built once the prisms can be projected into their display frame (see
+  // visualizationFrame()), then latched; invalidated on any rebuild.
   {
     std::scoped_lock lock(mutex_safety_area_);
     if (safety_zone_handler_.safety_zone && !safety_zone_handler_.visualization_components.initialized) {
       bool all_transforms_done = true;
 
-      // Transform prism to local_origin frame for visualization
-      auto border_prism      = safety_zone_handler_.safety_zone->getBorder();
-      auto transformed_prism = transformPrism(border_prism, "local_origin");
+      auto       border_prism      = safety_zone_handler_.safety_zone->getBorder();
+      const auto border_viz_frame  = visualizationFrame(border_prism);
+      auto       transformed_prism = transformPrism(border_prism, border_viz_frame);
 
       if (!transformed_prism) {
         all_transforms_done = false;
       } else {
         safety_zone_handler_.visualization_components.static_edges.push_back(
-            std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism.value(), _uav_name_, "local_origin", node_, 2));
+            std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_prism.value(), _uav_name_, border_viz_frame, node_, 2));
 
         // Obstacles if safety zone is already defined and transformed successfully
         const auto &obstacles = safety_zone_handler_.safety_zone->getObstacles();
         for (const auto &[id, obstacle_ptr] : obstacles) {
-          // Transform obstacle prism to local_origin frame
-          auto transformed_obstacle_prism = transformPrism(*obstacle_ptr, "local_origin");
+          const auto obstacle_viz_frame         = visualizationFrame(*obstacle_ptr);
+          auto       transformed_obstacle_prism = transformPrism(*obstacle_ptr, obstacle_viz_frame);
 
           if (!transformed_obstacle_prism) {
             all_transforms_done = false;
             break;
           }
           safety_zone_handler_.visualization_components.static_edges.push_back(
-              std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism.value(), _uav_name_, "local_origin", node_, 2));
+              std::make_unique<mrs_lib::StaticEdgesVisualization>(transformed_obstacle_prism.value(), _uav_name_, obstacle_viz_frame, node_, 2));
         }
       }
 
@@ -664,6 +667,15 @@ void SafetyAreaManager::timerStatus() {
 
       world_origin_changed_ = false;
     }
+
+    // a non-world_origin border needs no point rebuild (it follows the origin through tf), but its
+    // cached visualization was projected against the old origin - drop it and consume the offset
+    if (world_origin_changed_) {
+      safety_zone_handler_.visualization_components.safeCleanup();
+      world_origin_offset_x_ = 0.0;
+      world_origin_offset_y_ = 0.0;
+      world_origin_changed_  = false;
+    }
   }
 
   // Publishing
@@ -715,7 +727,7 @@ void SafetyAreaManager::callbackOdometry(const nav_msgs::msg::Odometry::ConstSha
 
 //}
 
-/* //{  point.callbackGNSS() */
+/* //{  callbackGNSS() */
 
 void SafetyAreaManager::callbackGNSS(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg) {
 
@@ -767,10 +779,10 @@ bool SafetyAreaManager::callbackAddObstacle(const std::shared_ptr<mrs_msgs::srv:
       mrs_lib::safety_zone::Point2d{-2.5 + offset_x, 2.5 + offset_y},
   };
 
-  int id = safety_zone_handler_.safety_zone->addObstacle(std::make_unique<mrs_lib::safety_zone::Prism>(points, 5, 0));
+  safety_zone_handler_.safety_zone->addObstacle(std::make_unique<mrs_lib::safety_zone::Prism>(points, 5, 0));
 
-  safety_zone_handler_.visualization_components.static_edges.push_back(
-      std::make_unique<mrs_lib::StaticEdgesVisualization>(safety_zone_handler_.safety_zone.get(), id, _uav_name_, horizontal_frame, node_, 2));
+  // let the status timer rebuild the visualization, so the obstacle is projected like the border
+  safety_zone_handler_.visualization_components.safeCleanup();
 
   RCLCPP_INFO(node_->get_logger(), "Obstacle loaded successfully");
 
@@ -811,10 +823,10 @@ bool SafetyAreaManager::callbackSetObstacle(const std::shared_ptr<mrs_msgs::srv:
     return true;
   }
 
-  int id = safety_zone_handler_.safety_zone->addObstacle(std::move(prism_ptr));
+  safety_zone_handler_.safety_zone->addObstacle(std::move(prism_ptr));
 
-  safety_zone_handler_.visualization_components.static_edges.push_back(
-      std::make_unique<mrs_lib::StaticEdgesVisualization>(safety_zone_handler_.safety_zone.get(), id, _uav_name_, request->prism.horizontal_frame, node_, 2));
+  // let the status timer rebuild the visualization, so the obstacle is projected like the border
+  safety_zone_handler_.visualization_components.safeCleanup();
 
   RCLCPP_INFO(node_->get_logger(), "Obstacle loaded successfully");
   response->message = "Successfully added the obstacle";
@@ -1493,6 +1505,23 @@ std::unique_ptr<mrs_lib::safety_zone::Prism> SafetyAreaManager::makePrism(const 
   }
 
   return prism;
+}
+
+//}
+
+/* visualizationFrame() //{ */
+
+// The frame a prism is projected into for RViz. Keep the prism's own frame so RViz transforms it
+// live; only latlon_origin needs remapping, to world_origin - RViz cannot evaluate the latlon
+// transform, and world_origin (unlike local_origin) is earth-fixed and not re-anchored on estimator
+// resets.
+std::string SafetyAreaManager::visualizationFrame(const mrs_lib::safety_zone::Prism &prism) {
+
+  if (prism.getHorizontalFrame() == "latlon_origin") {
+    return "world_origin";
+  }
+
+  return prism.getHorizontalFrame();
 }
 
 //}

--- a/src/safety_area_manager.cpp
+++ b/src/safety_area_manager.cpp
@@ -1831,10 +1831,10 @@ double SafetyAreaManager::getMaxZ() {
 
       if (!ret) {
         RCLCPP_WARN(node_->get_logger(), "Could not transform estimation manager's max_z to the "
-                                         "current safety area frame");
+                                         "current safety area frame; ignoring it for this query");
+      } else {
+        estimation_manager_max_z = ret->point.z;
       }
-
-      estimation_manager_max_z = ret->point.z;
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ function(add_mrs_uav_managers_test_target test_name)
       mrs_lib::mrs_lib
       mrs_uav_testing::mrs_uav_testing
       ${mrs_msgs_TARGETS}
+      ${visualization_msgs_TARGETS}
   )
 
   install(
@@ -49,4 +50,5 @@ add_subdirectory(control_manager)
 add_subdirectory(errorgraph)
 add_subdirectory(estimation_manager)
 add_subdirectory(gain_manager)
+add_subdirectory(safety_area_manager)
 add_subdirectory(uav_manager)

--- a/test/safety_area_manager/CMakeLists.txt
+++ b/test/safety_area_manager/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(rviz_markers)

--- a/test/safety_area_manager/rviz_markers/CMakeLists.txt
+++ b/test/safety_area_manager/rviz_markers/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+add_mrs_uav_managers_test_target("${TEST_NAME}")

--- a/test/safety_area_manager/rviz_markers/config/custom_config.yaml
+++ b/test/safety_area_manager/rviz_markers/config/custom_config.yaml
@@ -1,0 +1,16 @@
+# GET ALL PARAMETERS USABLE FOR CUSTOM CONFIG BY RUNNING:
+## --------------------------------------------------------------
+## |          rosrun mrs_uav_core get_public_params.py          #
+## --------------------------------------------------------------
+
+mrs_uav_managers:
+
+  estimation_manager:
+
+    # loaded state estimator plugins
+    state_estimators: [
+      "gps_garmin",
+    ]
+
+    initial_state_estimator: "gps_garmin" # will be used as the first state estimator
+    agl_height_estimator: "garmin_agl" # only slightly filtered height for checking min height (not used in control feedback)

--- a/test/safety_area_manager/rviz_markers/config/mrs_simulator.yaml
+++ b/test/safety_area_manager/rviz_markers/config/mrs_simulator.yaml
@@ -1,0 +1,11 @@
+# turning off for the takeoff test
+individual_takeoff_platform:
+  enabled: false
+
+uav1:
+  type: "x500"
+  spawn:
+    x: 10.0
+    y: 20.0
+    z: 0.5
+    heading: 1.2

--- a/test/safety_area_manager/rviz_markers/config/world_config.yaml
+++ b/test/safety_area_manager/rviz_markers/config/world_config.yaml
@@ -1,0 +1,39 @@
+mrs_uav_managers:
+
+  world_origin:
+
+    units: "LATLON"
+
+    origin_x: 47.397743
+    origin_y: 8.545594
+
+  safety_area_manager:
+
+    safety_area:
+
+      enabled: true
+
+      horizontal:
+
+        # mirrors the field config that triggered the bug: the border is defined in latlon_origin,
+        # a frame RViz cannot transform, so the manager has to pre-project it for visualization
+        frame_name: "latlon_origin"
+
+        # x = latitude, y = longitude [deg] - a ~110 x 110 m box around the world origin
+        points: [
+          47.397243, 8.544894,
+          47.397243, 8.546294,
+          47.398243, 8.546294,
+          47.398243, 8.544894,
+        ]
+
+      vertical:
+
+        frame_name: "world_origin"
+
+        max_z: 15.0
+        min_z: 1.0
+
+      obstacles:
+
+        present: false

--- a/test/safety_area_manager/rviz_markers/test.cpp
+++ b/test/safety_area_manager/rviz_markers/test.cpp
@@ -1,0 +1,281 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+
+#include <mrs_lib/gps_conversions.h>
+#include <mrs_lib/service_client_handler.h>
+
+#include <mrs_msgs/srv/reference_stamped_srv.hpp>
+
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <mrs_uav_testing/test_generic.h>
+
+#include <cmath>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+/* class Tester //{ */
+
+class Tester : public mrs_uav_testing::TestGeneric {
+
+public:
+  Tester() : mrs_uav_testing::TestGeneric() {
+  }
+
+  bool test(void);
+
+  std::shared_ptr<mrs_uav_testing::UAVHandler> uh_;
+
+private:
+  rclcpp::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr sub_markers_;
+  std::mutex                                                            markers_mtx_;
+  std::optional<visualization_msgs::msg::MarkerArray>                   last_markers_;
+
+  // the border edge marker, once it is being published with real geometry
+  std::optional<visualization_msgs::msg::Marker> waitForBorderMarker(const double timeout);
+
+  // the distinct polygon corners of a LINE_LIST border marker (the upper and lower ring collapse to one)
+  std::vector<geometry_msgs::msg::Point> markerCorners(const visualization_msgs::msg::Marker &marker);
+};
+
+//}
+
+/* waitForBorderMarker() //{ */
+
+std::optional<visualization_msgs::msg::Marker> Tester::waitForBorderMarker(const double timeout) {
+
+  const rclcpp::Time start = clock_->now();
+
+  while (rclcpp::ok() && (clock_->now() - start).seconds() < timeout) {
+
+    {
+      std::scoped_lock lock(markers_mtx_);
+
+      if (last_markers_) {
+        for (const auto &marker : last_markers_->markers) {
+          if (marker.type == visualization_msgs::msg::Marker::LINE_LIST && marker.action == visualization_msgs::msg::Marker::ADD && marker.points.size() >= 6) {
+            return marker;
+          }
+        }
+      }
+    }
+
+    this->sleep(0.2);
+  }
+
+  return std::nullopt;
+}
+
+//}
+
+/* markerCorners() //{ */
+
+std::vector<geometry_msgs::msg::Point> Tester::markerCorners(const visualization_msgs::msg::Marker &marker) {
+
+  // a LINE_LIST border marker repeats every polygon corner several times (at min_z and max_z, and
+  // shared between adjacent edges); collapse them back to the distinct corner positions by x and y
+  std::vector<geometry_msgs::msg::Point> corners;
+
+  for (const auto &point : marker.points) {
+
+    bool duplicate = false;
+
+    for (const auto &corner : corners) {
+      if (std::abs(point.x - corner.x) < 0.05 && std::abs(point.y - corner.y) < 0.05) {
+        duplicate = true;
+        break;
+      }
+    }
+
+    if (!duplicate) {
+      corners.push_back(point);
+    }
+  }
+
+  return corners;
+}
+
+//}
+
+/* test() //{ */
+
+bool Tester::test(void) {
+
+  const std::string uav_name     = "uav1";
+  const std::string world_frame  = uav_name + "/world_origin";
+  const std::string latlon_frame = uav_name + "/latlon_origin";
+
+  // the border corners as configured in config/world_config.yaml (x = latitude, y = longitude)
+  const std::vector<std::pair<double, double>> config_corners = {
+      {47.397243, 8.544894},
+      {47.397243, 8.546294},
+      {47.398243, 8.546294},
+      {47.398243, 8.544894},
+  };
+
+  // ~25 m from the configured origin
+  const double new_origin_lat = 47.397923;
+  const double new_origin_lon = 8.545794;
+
+  {
+    auto [uhopt, message] = getUAVHandler(uav_name);
+
+    if (!uhopt) {
+      RCLCPP_ERROR(node_->get_logger(), "Failed to obtain handler for '%s': '%s'", uav_name.c_str(), message.c_str());
+      return false;
+    }
+
+    uh_ = uhopt.value();
+  }
+
+  // the test's transformer needs the uav prefix (so latlon_origin resolves) and a utm zone (to
+  // invert world_origin -> latlon_origin)
+  uh_->transformer_->setDefaultPrefix(uav_name);
+  uh_->transformer_->setLatLon(47.397743, 8.545594);
+
+  sub_markers_ = node_->create_subscription<visualization_msgs::msg::MarkerArray>("/" + uav_name + "/safety_area_manager/static_markers", rclcpp::QoS(10),
+                                                                                  [this](const visualization_msgs::msg::MarkerArray::ConstSharedPtr msg) {
+                                                                                    std::scoped_lock lock(markers_mtx_);
+                                                                                    last_markers_ = *msg;
+                                                                                  });
+
+  auto sch_set_world_origin = mrs_lib::ServiceClientHandler<mrs_msgs::srv::ReferenceStampedSrv>(node_, "/" + uav_name + "/estimation_manager/set_world_origin");
+
+  // | ---------------------- wait for the system --------------------- |
+
+  while (rclcpp::ok() && !uh_->mrsSystemReady()) {
+    RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "waiting for the MRS UAV System");
+    this->sleep(0.01);
+  }
+
+  /* verify() //{ */
+
+  // takes the published border marker, checks it is in an RViz-usable earth-fixed frame, and
+  // transfers every vertex back to latlon_origin with mrs_lib to confirm the geometry RViz receives
+  // still describes the configured fence
+  const auto verify = [&](const std::string &when) -> bool {
+    auto marker = waitForBorderMarker(30.0);
+
+    if (!marker) {
+      RCLCPP_ERROR(node_->get_logger(), "no safety area border marker received %s", when.c_str());
+      return false;
+    }
+
+    if (marker->header.frame_id != world_frame) {
+      RCLCPP_ERROR(node_->get_logger(), "border marker is published in '%s' %s, expected '%s' (latlon_origin is not RViz-transformable, local_origin drifts)",
+                   marker->header.frame_id.c_str(), when.c_str(), world_frame.c_str());
+      return false;
+    }
+
+    const auto corners = markerCorners(*marker);
+
+    RCLCPP_INFO(node_->get_logger(), "border marker %s: frame '%s', %zu points, %zu distinct corners", when.c_str(), marker->header.frame_id.c_str(),
+                marker->points.size(), corners.size());
+
+    if (corners.size() != config_corners.size()) {
+      RCLCPP_ERROR(node_->get_logger(), "border marker has %zu distinct corners %s, expected %zu", corners.size(), when.c_str(), config_corners.size());
+      return false;
+    }
+
+    const double tolerance = 1.0; // [m]
+
+    for (const auto &vertex : corners) {
+
+      mrs_msgs::msg::ReferenceStamped ref;
+      ref.header.frame_id      = world_frame;
+      ref.reference.position.x = vertex.x;
+      ref.reference.position.y = vertex.y;
+
+      auto latlon = uh_->transformer_->transformSingle(ref, latlon_frame);
+
+      if (!latlon) {
+        RCLCPP_ERROR(node_->get_logger(), "could not transform a border marker vertex back to latlon_origin %s", when.c_str());
+        return false;
+      }
+
+      double vertex_utm_x, vertex_utm_y;
+      mrs_lib::UTM(latlon->reference.position.x, latlon->reference.position.y, &vertex_utm_x, &vertex_utm_y);
+
+      bool matched = false;
+
+      for (const auto &[corner_lat, corner_lon] : config_corners) {
+        double corner_utm_x, corner_utm_y;
+        mrs_lib::UTM(corner_lat, corner_lon, &corner_utm_x, &corner_utm_y);
+        if (std::hypot(vertex_utm_x - corner_utm_x, vertex_utm_y - corner_utm_y) < tolerance) {
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        RCLCPP_ERROR(node_->get_logger(), "border marker vertex (%.2f, %.2f) maps to lat %.6f lon %.6f %s - not a configured corner (stale or mis-projected)",
+                     vertex.x, vertex.y, latlon->reference.position.x, latlon->reference.position.y, when.c_str());
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  //}
+
+  if (!verify("on startup")) {
+    return false;
+  }
+
+  // | ------------- move the world origin at runtime ------------ |
+
+  // the latlon_origin border is physically unchanged, but world_origin re-anchors under it - a
+  // correct visualization must drop its cached projection and rebuild against the new origin
+  {
+    auto request = std::make_shared<mrs_msgs::srv::ReferenceStampedSrv::Request>();
+
+    request->header.frame_id      = "latlon_origin";
+    request->reference.position.x = new_origin_lat;
+    request->reference.position.y = new_origin_lon;
+
+    auto response = sch_set_world_origin.callSync(request);
+
+    if (!response || !response.value()->success) {
+      RCLCPP_ERROR(node_->get_logger(), "set_world_origin failed: '%s'", response ? response.value()->message.c_str() : "no response");
+      return false;
+    }
+  }
+
+  // let the estimators reset and the manager rebuild the visualization
+  this->sleep(5.0);
+
+  if (!verify("after the world origin change")) {
+    return false;
+  }
+
+  return true;
+}
+
+//}
+
+/* main() //{ */
+
+int main(int argc, char *argv[]) {
+
+  rclcpp::init(argc, argv);
+
+  bool test_result = true;
+
+  Tester tester;
+
+  test_result &= tester.test();
+
+  tester.sleep(2.0);
+
+  std::cout << "Test: reporting test results" << std::endl;
+
+  tester.reportTestResult(test_result);
+
+  tester.join();
+}
+
+//}

--- a/test/safety_area_manager/rviz_markers/test.py
+++ b/test/safety_area_manager/rviz_markers/test.py
@@ -1,0 +1,185 @@
+import time
+import unittest
+import os
+import sys
+
+import launch
+import launch_ros
+import launch_testing.actions
+import launch_testing.asserts
+from launch.actions import IncludeLaunchDescription, GroupAction, SetEnvironmentVariable, DeclareLaunchArgument
+import rclpy
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+
+from std_msgs.msg import Bool
+
+def generate_test_description():
+
+    ld = launch.LaunchDescription()
+
+    launch_file_path = os.path.abspath(__file__)
+    launch_dir = os.path.dirname(launch_file_path)
+
+    test_name = os.path.basename(launch_dir)
+
+    uav_name="uav1"
+
+    platform_config=get_package_share_directory("mrs_multirotor_simulator")+"/config/mrs_uav_system/x500.yaml",
+
+    current_rmw = os.environ.get('RMW_IMPLEMENTATION', '')
+
+    if current_rmw == 'rmw_zenoh_cpp':
+        ld.add_action(
+            launch_ros.actions.Node(
+                package='rmw_zenoh_cpp',
+                namespace='',
+                executable='rmw_zenohd',
+                name='zenoh_router',
+                output='screen'
+            )
+        )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                            'launch',
+                            'mrs_multirotor_simulator.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'custom_config': launch_dir+"/config/mrs_simulator.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_uav_testing'),
+                        'launch',
+                        'mrs_uav_system.launch.py'
+                        ])
+                    ]),
+                    launch_arguments={
+                        'run_automatic_start': "true",
+                        # 'standalone': "true",
+                        'uav_name': uav_name,
+                        'platform_config': platform_config,
+                        'world_config': launch_dir+"/config/world_config.yaml",
+                        'custom_config': launch_dir+"/config/custom_config.yaml",
+                        # 'automatic_start_config': launch_dir+"/config/automatic_start.yaml",
+                    }.items()
+                )
+            ]
+        )
+    )
+
+    ld.add_action(
+        GroupAction([
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('mrs_multirotor_simulator'),
+                            'launch',
+                            'hw_api.launch.py'
+                        ])
+                    ]),
+                )
+            ]
+        )
+    )
+
+    # starts the integration interactor
+    ld.add_action(
+            # Nodes under test
+            launch_ros.actions.Node(
+                package='mrs_uav_managers',
+                namespace='',
+                executable='test_'+test_name,
+                name='test_'+test_name,
+                output="screen",
+                parameters=[
+                        {'test_name': test_name},
+                ],
+            )
+        )
+
+    # starts the python test part down below
+    ld.add_action(
+        launch.actions.TimerAction(
+            period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        )
+
+    return ld
+
+# #{ class PublisherHandlerTest(unittest.TestCase)
+
+class PublisherHandlerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('integration_test_handler')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_interactor(self, proc_output, timeout=120):
+
+        """Check whether pose messages published"""
+
+        test_result = []
+
+        sub = self.node.create_subscription(
+                Bool, '/test_result',
+                lambda msg: test_result.append(msg), 100)
+        try:
+
+            end_time = time.time() + timeout
+
+            while time.time() < end_time:
+
+                if len(test_result) > 0:
+                    break
+
+                rclpy.spin_once(self.node, timeout_sec=1)
+
+            time.sleep(2.0)
+
+            # check if we have the result
+            self.assertTrue(len(test_result) > 0)
+
+            # check if the result is true
+            self.assertTrue(test_result[0].data)
+
+        finally:
+            self.node.destroy_subscription(sub)
+
+# #} end of
+
+# #{ Post-shutdown tests
+
+# @launch_testing.post_shutdown_test()
+# class PublisherHandlerTestShutdown(unittest.TestCase):
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)
+
+# #} end of Post-shutdown tests


### PR DESCRIPTION
## Summary
- **What changed**:
  - Prisms are now projected into their own configured frame for RViz (new `visualizationFrame()`) instead of always `local_origin`, remapping `latlon_origin` -> `world_origin` since RViz can't evaluate the latlon transform.
  - `getMaxZ()` no longer dereferences a `nullopt` transform result.
  - added test for visualization of safety area
- **Why**:
  - RViz showed the safety zone in the wrong place for any border configured in a frame other than `local_origin`.
- **Notes for reviewers**:
  - Depends on https://github.com/ctu-mrs/mrs_lib/pull/126 — test will crash without it.

## Impact
- **Affected areas**: `SafetyAreaManager` (`src/safety_area_manager.cpp`), new `test/safety_area_manager/rviz_markers/`
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon test --packages-select mrs_uav_managers --ctest-args -R 'test_rviz_markers'
colcon test-result --verbose
```